### PR TITLE
feat: implement TOON spec v3.0.3 (v1.2.0)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is an n8n community node for bidirectional conversion between TOON (Token-Oriented Object Notation) and JSON formats. The implementation follows the **TOON Specification v3.0** (see `SPEC.md`) with **zero external production dependencies**.
+This is an n8n community node for bidirectional conversion between TOON (Token-Oriented Object Notation) and JSON formats. The implementation follows the **TOON Specification v3.0.3** (see `SPEC.md`) with **zero external production dependencies**.
 
 ## Development Setup
 
@@ -46,7 +46,7 @@ nodes/Toon/
 ├── Toon.node.ts          # Main n8n node implementation
 ├── Toon.node.json        # Node metadata
 ├── toon.svg              # Node icon
-└── __tests__/            # Test suite (161 tests)
+└── __tests__/            # Test suite (179 tests)
     ├── ToonUtils.test.ts
     ├── ToonEncoder.test.ts
     ├── ToonDecoder.test.ts
@@ -81,31 +81,35 @@ nodes/Toon/
 
 ## TOON Specification Compliance
 
-| Spec Section | Feature | Status |
-|-------------|---------|---------|
-| §2 | Canonical number format | ✅ |
-| §3 | Value normalization | ✅ |
-| §4 | Type inference | ✅ |
-| §5 | Root form determination | ✅ |
-| §6 | Array header format | ✅ |
-| §7 | String quoting and escaping | ✅ |
-| §9.3 | Tabular array detection | ✅ |
-| §11 | Delimiter scoping | ✅ |
-| §12 | Indentation rules | ✅ |
-| §13.4 | Key folding/path expansion | ✅ |
-| §14 | Strict mode validation | ✅ |
+Spec version: **3.0.3** — tracked in `package.json` field `toonSpecVersion`.
+
+| Spec Section | Feature | Implementation | Status |
+|---|---|---|---|
+| §2 | Canonical number format (no exponent, no trailing zeros, -0→0) | `ToonUtils.canonicalizeNumber` | ✅ |
+| §3 | Value normalization (undefined/function/symbol/NaN/Infinity→null) | `ToonEncoder.normalizeValue` | ✅ |
+| §3 | `toJSON()` hook honored before normalization *(v3.0.3)* | `ToonEncoder.normalizeValue` | ✅ |
+| §4 | Type inference (boolean, null, number, string) | `ToonUtils.parseToken` | ✅ |
+| §4 | Forbidden leading zeros in integer part treated as strings *(v3.0.3)* | `ToonUtils.isNumericToken` | ✅ |
+| §5 | Root form determination (array / primitive / object) | `ToonDecoder.determineRootForm` | ✅ |
+| §6 | Array header parsing (`[N]`, `[N\t]`, `[N\|]`) | `ToonDecoder.parseArrayHeader` | ✅ |
+| §7.1 | String escaping (`\\`, `\"`, `\n`, `\r`, `\t`) | `ToonUtils.escapeString` / `unescapeString` | ✅ |
+| §7.2 | String quoting rules (reserved words, numbers, delimiters, etc.) | `ToonUtils.needsQuoting` | ✅ |
+| §7.3 | Key quoting rules | `ToonUtils.keyNeedsQuoting` | ✅ |
+| §8 | Key-value parsing | `ToonDecoder.parseObject` | ✅ |
+| §9.3 | Tabular array detection (uniform objects with primitive values) | `ToonUtils.isUniformArray`, `ToonEncoder.encodeTabular` | ✅ |
+| §9.3 | Non-whitespace between `]` and `{`/`:` → fall-through to key-value *(v3.0.3)* | `ToonDecoder.isValidArrayHeader` | ✅ |
+| §11 | Delimiter scoping (comma / tab / pipe) | `ToonDecoder.parseDelimitedTokens`, `ToonEncoder.encodePrimitiveArray` | ✅ |
+| §12 | No trailing newline | `ToonEncoder.encode` | ✅ |
+| §13.4 | Key folding (safe mode, dotted paths) | `ToonEncoder.foldKeys` | ✅ |
+| §13.4 | Path expansion (safe mode) | `ToonDecoder.expandPaths` | ✅ |
+| §14 | Strict mode: indentation, array counts, tab errors | `ToonDecoder.parseLines`, `parseArray`, `parseTabularArray` | ✅ |
+| §14 | Strict mode: invalid array header (non-whitespace between `]` and `{`/`:`) *(v3.0.3)* | `ToonDecoder.isInvalidArrayHeader` | ✅ |
 
 ## Testing
 
 ```bash
-# Run all tests (161 tests)
+# Run all tests (179 tests)
 npm test
-
-# Coverage achieved:
-# - ToonEncoder: 96% (82 tests)
-# - ToonDecoder: 83% (83 tests)
-# - ToonUtils: 76% (24 tests)
-# - Integration: 36 tests
 ```
 
 ## Pre-commit Checklist

--- a/SPEC-v3.0-archived.md
+++ b/SPEC-v3.0-archived.md
@@ -217,7 +217,7 @@ Implementations that fail to conform to any MUST or REQUIRED level requirement a
   - Encoders SHOULD provide an option to choose lossless stringification for out-of-range numbers.
 - Numbers (decoding):
   - Decoders MUST accept decimal and exponent forms on input (e.g., 42, -3.14, 1e-6, -1E+9).
-  - Decoders MUST treat tokens with forbidden leading zeros in the integer part (e.g., `"05"`, `"0001"`, `"-05"`, `"-0001"`) as strings, not numbers. This rule does **not** apply to a single zero integer part followed by a fractional or exponent part (e.g., `0.5`, `0e1`, `-0.5`, `-0e1`), which are valid numbers.
+  - Decoders MUST treat tokens with forbidden leading zeros (e.g., "05", "0001") as strings, not numbers.
   - If a decoded numeric token is not representable in the host's default numeric type without loss, implementations MAY:
     - Return a higher-precision numeric type (e.g., arbitrary-precision integer or decimal), OR
     - Return a string, OR
@@ -232,7 +232,6 @@ Encoders MUST normalize non-JSON values to the JSON data model before encoding. 
 - Number:
   - Finite → number (canonical decimal form per Section 2). -0 → 0.
   - NaN, +Infinity, -Infinity → null.
-- Implementations MAY honor host-language–specific serialization hooks (for example, a `toJSON()` method in JavaScript or an equivalent mechanism) as part of host-type normalization. When supported, such hooks SHOULD be applied before other host-type mappings and their behavior MUST be documented by the implementation.
 - Examples of host-type normalization (non-normative):
   - Date/time objects → ISO 8601 string representation.
   - Set-like collections → array.
@@ -348,8 +347,6 @@ unquoted-key  = ( ALPHA / "_" ) *( ALPHA / DIGIT / "_" / "." )
 Note: The ABNF grammar above cannot enforce that the delimiter used in the fields segment (braces) matches the delimiter declared in the bracket segment. This equality requirement is normative per the prose in lines 311-312 above and MUST be enforced by implementations. Mismatched delimiters between bracket and brace segments MUST error in strict mode.
 
 Note: The grammar above specifies header syntax. TOON's grammar is deliberately designed to prioritize human readability and token efficiency over strict LR(1) parseability. This requires some context-sensitive parsing (particularly for tabular row disambiguation in Section 9.3), which is a deliberate design tradeoff. Reference implementations demonstrate that deterministic parsing is achievable with modest lookahead.
-
-Between the closing bracket `]` of the bracket segment and the opening brace `{` of a fields segment (or the colon `:` if no fields segment is present), only whitespace MAY appear. If a decoder encounters non-whitespace content in these positions (e.g., additional bracket expressions like `[bar]`), the line MUST NOT be interpreted as an array header. Decoders SHOULD fall through to key-value parsing (Section 8), treating the entire pre-colon content as a literal key.
 
 Decoding requirements:
 - The bracket segment MUST parse as a non-negative integer length N.
@@ -731,7 +728,6 @@ When strict mode is enabled (default), decoders MUST error on the following cond
 - Missing colon in key context.
 - Invalid escape sequences or unterminated strings in quoted tokens.
 - Delimiter mismatch (detected via width/count checks and header scope).
-- Non-whitespace content between a valid bracket segment and the colon (or fields segment). Such lines MUST NOT be parsed as array headers. Decoders MUST NOT silently discard content in these positions.
 
 ### 14.3 Indentation Errors
 
@@ -1338,7 +1334,6 @@ Collection Types:
 - `Map`: Convert to object using `String(key)` for keys and normalizing values recursively. Non-string keys are coerced to strings.
 
 Object Types:
-- Objects with a `toJSON()` method: Call `value.toJSON()` and then normalize the returned value recursively before encoding. This allows domain objects to override default normalization behavior in a controlled, deterministic way (similar to `JSON.stringify`). Implementations SHOULD guard against `toJSON()` returning the same object (to avoid infinite recursion) and MAY fall back to default normalization in that case.
 - Plain objects: Enumerate own enumerable string keys in encounter order; normalize values recursively.
 
 Non-Serializable Types:

--- a/nodes/Toon/ToonDecoder.ts
+++ b/nodes/Toon/ToonDecoder.ts
@@ -103,8 +103,8 @@ export class ToonDecoder {
     const firstLine = lines[0].content.trim();
 
     // Check for array header pattern per §6
-    // Only treat as array if it starts with [ (no key before it)
-    if (/^\[\d+[\t|]?\]/.test(firstLine)) {
+    // Only treat as array if it starts with [ (no key before it) and is a valid array header
+    if (/^\[\d+[\t|]?\]/.test(firstLine) && this.isValidArrayHeader(firstLine)) {
       return 'array';
     }
 
@@ -124,7 +124,8 @@ export class ToonDecoder {
     const content = line.content.trim();
 
     // Match pattern: optional_key [length delimiter_symbol] optional_{fields} : optional_values
-    const match = content.match(/^(.*?)\[(\d+)([\t|])?\](?:\{([^}]+)\})?:(.*)$/);
+    // Per §9.3: only whitespace may appear between ] and { or : — non-whitespace means it's not an array header
+    const match = content.match(/^(.*?)\[(\d+)([\t|])?\]\s*(?:\{([^}]+)\}\s*)?:(.*)$/);
 
     if (!match) {
       throw new ToonDecodingError('Invalid array header format', {
@@ -319,8 +320,8 @@ export class ToonDecoder {
       // Parse element
       const content = line.content.trim();
 
-      // Check if it's a nested array
-      if (/^\[\d+[\t|]?\]/.test(content)) {
+      // Check if it's a nested array (must be a valid array header per §9.3)
+      if (/^\[\d+[\t|]?\]/.test(content) && this.isValidArrayHeader(content)) {
         // Save any pending object first
         if (currentObj !== null) {
           values.push(currentObj);
@@ -516,8 +517,8 @@ export class ToonDecoder {
       // Parse key-value pair
       const content = line.content.trim();
 
-      // Check for array
-      if (/\[\d+[\t|]?\]/.test(content)) {
+      // Check for array (must be a valid array header per §9.3 — non-whitespace between ] and {/: → fall-through to key-value)
+      if (/\[\d+[\t|]?\]/.test(content) && this.isValidArrayHeader(content)) {
         const headerMatch = content.match(/^(.*?)\[/);
         if (headerMatch && headerMatch[1].trim()) {
           // Named array
@@ -558,8 +559,8 @@ export class ToonDecoder {
         // Nested object or array on next lines
         const nextLine = currentIndex + 1 < lines.length ? lines[currentIndex + 1] : null;
         if (nextLine && !nextLine.isEmpty && nextLine.indent > line.indent) {
-          // Check if next line is array
-          if (/\[\d+[\t|]?\]/.test(nextLine.content.trim())) {
+          // Check if next line is array (must be a valid array header per §9.3)
+          if (/\[\d+[\t|]?\]/.test(nextLine.content.trim()) && this.isValidArrayHeader(nextLine.content.trim())) {
             const array = this.parseArray(lines, currentIndex + 1);
             obj[key] = array;
             currentIndex = this.findNextSiblingIndex(lines, currentIndex + 1, line.indent);
@@ -582,6 +583,14 @@ export class ToonDecoder {
     }
 
     return obj;
+  }
+
+  /**
+   * Check if a line content is a valid array header per §9.3
+   * Only whitespace may appear between ] and { or : — non-whitespace means fall-through to key-value
+   */
+  private isValidArrayHeader(content: string): boolean {
+    return /^(.*?)\[(\d+)([\t|])?\]\s*(?:\{[^}]+\}\s*)?:/.test(content);
   }
 
   /**

--- a/nodes/Toon/ToonDecoder.ts
+++ b/nodes/Toon/ToonDecoder.ts
@@ -108,6 +108,14 @@ export class ToonDecoder {
       return 'array';
     }
 
+    // Per §14: non-whitespace between bracket segment and {/: is a decoding error in strict mode
+    if (this.options.strict && this.isInvalidArrayHeader(firstLine)) {
+      throw new ToonDecodingError(
+        'Non-whitespace content between bracket segment and colon/fields: line MUST NOT be parsed as array header',
+        { lineNumber: lines[0].lineNumber, line: firstLine },
+      );
+    }
+
     // Check if single line and no colon (primitive)
     if (lines.length === 1 && !firstLine.includes(':')) {
       return 'primitive';
@@ -320,6 +328,14 @@ export class ToonDecoder {
       // Parse element
       const content = line.content.trim();
 
+      // Per §14: strict mode error for non-whitespace between bracket segment and {/:
+      if (this.options.strict && this.isInvalidArrayHeader(content)) {
+        throw new ToonDecodingError(
+          'Non-whitespace content between bracket segment and colon/fields: line MUST NOT be parsed as array header',
+          { lineNumber: line.lineNumber, line: content },
+        );
+      }
+
       // Check if it's a nested array (must be a valid array header per §9.3)
       if (/^\[\d+[\t|]?\]/.test(content) && this.isValidArrayHeader(content)) {
         // Save any pending object first
@@ -517,6 +533,14 @@ export class ToonDecoder {
       // Parse key-value pair
       const content = line.content.trim();
 
+      // Per §14: strict mode error for non-whitespace between bracket segment and {/:
+      if (this.options.strict && this.isInvalidArrayHeader(content)) {
+        throw new ToonDecodingError(
+          'Non-whitespace content between bracket segment and colon/fields: line MUST NOT be parsed as array header',
+          { lineNumber: line.lineNumber, line: content },
+        );
+      }
+
       // Check for array (must be a valid array header per §9.3 — non-whitespace between ] and {/: → fall-through to key-value)
       if (/\[\d+[\t|]?\]/.test(content) && this.isValidArrayHeader(content)) {
         const headerMatch = content.match(/^(.*?)\[/);
@@ -591,6 +615,14 @@ export class ToonDecoder {
    */
   private isValidArrayHeader(content: string): boolean {
     return /^(.*?)\[(\d+)([\t|])?\]\s*(?:\{[^}]+\}\s*)?:/.test(content);
+  }
+
+  /**
+   * Check if a line looks like an array header but has non-whitespace between ] and {/:
+   * Per §14: such lines are a decoding error in strict mode
+   */
+  private isInvalidArrayHeader(content: string): boolean {
+    return /\[\d+[\t|]?\]/.test(content) && !this.isValidArrayHeader(content);
   }
 
   /**

--- a/nodes/Toon/ToonEncoder.ts
+++ b/nodes/Toon/ToonEncoder.ts
@@ -58,6 +58,20 @@ export class ToonEncoder {
       return value;
     }
 
+    // Per §3: honor toJSON() hook before other host-type mappings
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as Record<string, unknown>)['toJSON'] === 'function'
+    ) {
+      const toJSON = (value as Record<string, unknown>)['toJSON'] as () => unknown;
+      const serialized = toJSON.call(value);
+      // Guard against toJSON() returning the same object (infinite recursion)
+      if (serialized !== value) {
+        return this.normalizeValue(serialized);
+      }
+    }
+
     if (Array.isArray(value)) {
       return value.map((item) => this.normalizeValue(item));
     }

--- a/nodes/Toon/ToonUtils.ts
+++ b/nodes/Toon/ToonUtils.ts
@@ -232,9 +232,21 @@ function expandExponentialNotation(num: number): string {
 
 /**
  * Check if a string token looks like a number
+ * Per §4: tokens with forbidden leading zeros in the integer part are strings.
+ * Forbidden: "05", "0001", "-05", "-0001"
+ * Allowed: "0.5", "0e1", "-0.5", "-0e1" (zero integer part with fractional/exponent)
  */
 export function isNumericToken(token: string): boolean {
-  return /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(token) && token !== '' && token !== '-';
+  if (!/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(token) || token === '' || token === '-') {
+    return false;
+  }
+  // Reject forbidden leading zeros: integer part > 1 digit starting with 0
+  // e.g. "05", "0001", "-05", "-0001" → string
+  // but "0.5", "0e1", "-0.5", "-0e1" → valid number (zero integer part + fractional/exponent)
+  if (/^-?0\d/.test(token) && !/^-?0[.eE]/.test(token)) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/nodes/Toon/__tests__/ToonDecoder.test.ts
+++ b/nodes/Toon/__tests__/ToonDecoder.test.ts
@@ -443,6 +443,37 @@ describe('ToonDecoder', () => {
     });
   });
 
+  describe('leading zeros (§4 v3.0.3)', () => {
+    it('should treat tokens with forbidden leading zeros as strings', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('key: 05')).toEqual({ key: '05' });
+      expect(decoder.decode('key: 0001')).toEqual({ key: '0001' });
+      expect(decoder.decode('key: -05')).toEqual({ key: '-05' });
+      expect(decoder.decode('key: -0001')).toEqual({ key: '-0001' });
+    });
+
+    it('should treat zero integer part with fractional/exponent as numbers', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('key: 0.5')).toEqual({ key: 0.5 });
+      expect(decoder.decode('key: 0e1')).toEqual({ key: 0 });
+      expect(decoder.decode('key: -0.5')).toEqual({ key: -0.5 });
+      expect(decoder.decode('key: -0e1')).toEqual({ key: -0 });
+    });
+  });
+
+  describe('array header fall-through (§9.3 v3.0.3)', () => {
+    it('should treat non-whitespace between ] and : as key-value, not array header', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      // foo[2][bar]: x → literal key, not array header
+      expect(decoder.decode('foo[2][bar]: x')).toEqual({ 'foo[2][bar]': 'x' });
+    });
+
+    it('should still parse valid array headers with whitespace between ] and :', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('items[2]: a, b')).toEqual({ items: ['a', 'b'] });
+    });
+  });
+
   describe('error handling', () => {
     it('should parse malformed array-like keys as object keys', () => {
       const decoder = new ToonDecoder(defaultOptions);

--- a/nodes/Toon/__tests__/ToonDecoder.test.ts
+++ b/nodes/Toon/__tests__/ToonDecoder.test.ts
@@ -472,6 +472,12 @@ describe('ToonDecoder', () => {
       const decoder = new ToonDecoder(defaultOptions);
       expect(decoder.decode('items[2]: a, b')).toEqual({ items: ['a', 'b'] });
     });
+
+    it('should throw in strict mode when non-whitespace appears between ] and : (§14 v3.0.3)', () => {
+      const decoder = new ToonDecoder({ indent: 2, strict: true, expandPaths: 'off' });
+      expect(() => decoder.decode('foo[2][bar]: x')).toThrow(ToonDecodingError);
+      expect(() => decoder.decode('foo[2][bar]: x')).toThrow('MUST NOT be parsed as array header');
+    });
   });
 
   describe('error handling', () => {

--- a/nodes/Toon/__tests__/ToonEncoder.test.ts
+++ b/nodes/Toon/__tests__/ToonEncoder.test.ts
@@ -609,4 +609,35 @@ describe('ToonEncoder', () => {
       expect(result).toContain('flags[3]: true, false, true');
     });
   });
+
+  describe('toJSON() hook (§3 v3.0.3)', () => {
+    it('should call toJSON() before normalization', () => {
+      const encoder = new ToonEncoder(defaultOptions);
+      const obj = {
+        toJSON() {
+          return { name: 'Alice', age: 30 };
+        },
+      };
+      expect(encoder.encode(obj)).toBe('name: Alice\nage: 30');
+    });
+
+    it('should recursively normalize toJSON() result', () => {
+      const encoder = new ToonEncoder(defaultOptions);
+      const obj = {
+        toJSON() {
+          return { date: new Date('2024-01-01T00:00:00.000Z') };
+        },
+      };
+      // Date has its own toJSON() which returns ISO string (quoted because it contains colons)
+      expect(encoder.encode(obj)).toBe('date: "2024-01-01T00:00:00.000Z"');
+    });
+
+    it('should not infinitely recurse when toJSON() returns itself', () => {
+      const encoder = new ToonEncoder(defaultOptions);
+      const obj: Record<string, unknown> = { value: 42 };
+      obj['toJSON'] = () => obj; // returns same object
+      // Should fall back to plain object normalization
+      expect(encoder.encode(obj)).toContain('value: 42');
+    });
+  });
 });

--- a/nodes/Toon/__tests__/ToonUtils.test.ts
+++ b/nodes/Toon/__tests__/ToonUtils.test.ts
@@ -147,4 +147,28 @@ describe('ToonUtils', () => {
       expect(utils.isSafeKey('value123')).toBe(true);
     });
   });
+
+  describe('isNumericToken', () => {
+    it('should accept normal integers and decimals', () => {
+      expect(utils.isNumericToken('0')).toBe(true);
+      expect(utils.isNumericToken('42')).toBe(true);
+      expect(utils.isNumericToken('-5')).toBe(true);
+      expect(utils.isNumericToken('3.14')).toBe(true);
+      expect(utils.isNumericToken('-2.5')).toBe(true);
+    });
+
+    it('should accept zero integer part with fractional or exponent (per §4 v3.0.3)', () => {
+      expect(utils.isNumericToken('0.5')).toBe(true);
+      expect(utils.isNumericToken('0e1')).toBe(true);
+      expect(utils.isNumericToken('-0.5')).toBe(true);
+      expect(utils.isNumericToken('-0e1')).toBe(true);
+    });
+
+    it('should reject forbidden leading zeros in integer part (per §4 v3.0.3)', () => {
+      expect(utils.isNumericToken('05')).toBe(false);
+      expect(utils.isNumericToken('0001')).toBe(false);
+      expect(utils.isNumericToken('-05')).toBe(false);
+      expect(utils.isNumericToken('-0001')).toBe(false);
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.1.8",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.1.8",
+			"version": "1.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@tehw0lf/n8n-nodes-toon",
 	"version": "1.1.8",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
-	"toonSpecVersion": "3.0",
+	"toonSpecVersion": "3.0.3",
 	"license": "MIT",
 	"homepage": "https://github.com/tehw0lf/n8n-nodes-toon#readme",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.1.8",
+	"version": "1.2.0",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.0.3",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- Update `SPEC.md` to v3.0.3, archive v3.0 as `SPEC-v3.0-archived.md`
- Implement all 4 spec changes from v3.0.3:
  - **§4**: Negative leading zeros (`-05`, `-0001`) → string (was only positive before)
  - **§3**: Honor `toJSON()` hook before normalization in encoder
  - **§9.3**: Non-whitespace between `]` and `{`/`:` → fall-through to key-value parsing
  - **§14**: Strict mode throws `ToonDecodingError` for invalid array headers
- Update compliance table in `DEVELOPMENT.md` with file/function references
- Bump version `1.1.8` → `1.2.0`

## Test plan
- [x] 179 tests passing (11 new tests added)
- [x] lint clean
- [x] build successful

Closes #5