### PR TITLE
fix: omit dev dependencies from npm audit in security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,6 +35,7 @@ jobs:
     with:
       tool: "npm"
       semgrep_rules: "auto p/security-audit p/owasp-top-ten p/ci p/nodejs p/typescript"
+      npm_audit_omit_dev: true
 
   # Download artifacts from latest CI build
   # Note: Reuses artifacts from the main CI workflow instead of rebuilding


### PR DESCRIPTION
Add npm_audit_omit_dev: true to security scan workflow — minimatch and undici findings are dev-only (eslint-plugin-n8n-nodes-base, release-it) with no upstream fix available without breaking changes.