### PR TITLE
chore(release): bump version to 1.2.1, enable npm provenance publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
       build_main: "run build"
       artifact_path: "dist"
       library_path: "dist"
-      publish_github_release: "false"
+      publish_github_release: "true"
       npm_audit_omit_dev: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.0.3",
 	"license": "MIT",
@@ -32,8 +32,7 @@
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"test:coverage": "jest --coverage",
-		"release": "n8n-node release",
-		"prepublishOnly": "n8n-node prerelease"
+		"release": "n8n-node release"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
## Summary
- Bump version to 1.2.1
- Remove `prepublishOnly: n8n-node prerelease` script (blocks direct `npm publish` outside n8n-node CLI)
- Set `publish_github_release: "true"` in ci.yml (was `"false"`)

## Test plan
- [x] Merge workflows#49 first (already done)
- [x] Merge this PR → CI should publish to npm with provenance and create a GitHub Release automatically