### PR TITLE
fix(ci): add pull-requests:write permission for npm audit autofix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
+      pull-requests: write
     with:
       tool: "npm"
       lint: "run lint"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  pull-requests: write
 
 jobs:
   # Scan source code for security vulnerabilities
@@ -29,9 +30,10 @@ jobs:
     name: Scan Source Code
     uses: tehw0lf/workflows/.github/workflows/security-scan-source.yml@main
     permissions:
-      contents: read
+      contents: write
       security-events: write
       actions: read
+      pull-requests: write
     with:
       tool: "npm"
       semgrep_rules: "auto p/security-audit p/owasp-top-ten p/ci p/nodejs p/typescript"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,9 +2543,9 @@
 			}
 		},
 		"node_modules/@n8n/errors": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.6.0.tgz",
-			"integrity": "sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.7.0.tgz",
+			"integrity": "sha512-fz3VnXwiCk8B+u5vPg/49hz0b9X/RRMdaG+BgV9bozDMu390e2obAx9GPY75e3wht+p6i+6gt3C16eBabcXwNA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
@@ -2567,17 +2567,18 @@
 			}
 		},
 		"node_modules/@n8n/expression-runtime": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.4.0.tgz",
-			"integrity": "sha512-KYXTedMMqrLEzkcVhv8jCHyg/34RgI0wwDNL3Sc0QhXkNRZnBrjRjbs2d9ZrJKj1OTzj46Ozp0iEfmJYnOW1Ow==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.9.0.tgz",
+			"integrity": "sha512-GfNiNnr96MxWnSs8fzMgDH5OlVjFMOIodUOtjORqaEvQEKUy5E8AE0VVLmLGmFHQgcJw/H8uP3OT7Iv1POb/tQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
+				"@n8n/errors": "0.7.0",
 				"@n8n/tournament": "1.0.6",
 				"isolated-vm": "^6.0.2",
-				"js-base64": "3.7.2",
+				"js-base64": "3.7.8",
 				"jssha": "3.3.1",
-				"lodash": "4.17.23",
+				"lodash": "4.18.1",
 				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"title-case": "3.0.3",
@@ -4256,15 +4257,15 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -9096,9 +9097,9 @@
 			}
 		},
 		"node_modules/js-base64": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-			"integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
+			"version": "3.7.8",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+			"integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
@@ -9284,9 +9285,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.capitalize": {
@@ -9597,29 +9598,30 @@
 			}
 		},
 		"node_modules/n8n-workflow": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.12.0.tgz",
-			"integrity": "sha512-vcr7XXrrzL4d6+ea1MHkgXHni25/M496ODSBzBxIn46UAbXcEcjHHgmOgmN5rdHtnjKfiy5xD/Bw18PqwlvP0A==",
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.17.0.tgz",
+			"integrity": "sha512-OPgWQz1Gg3BOmbJCxLO8w3LM3g5zAhik7M890RLTGhXFdhoGzaAVBWyrWWbIA9w8UpP9qNxiuosfTAfrAkh+Kw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "0.6.0",
-				"@n8n/expression-runtime": "0.4.0",
+				"@n8n/errors": "0.7.0",
+				"@n8n/expression-runtime": "0.9.0",
 				"@n8n/tournament": "1.0.6",
 				"ast-types": "0.16.1",
 				"callsites": "3.1.0",
 				"esprima-next": "5.8.4",
 				"form-data": "4.0.4",
 				"jmespath": "0.16.0",
-				"js-base64": "3.7.2",
+				"js-base64": "3.7.8",
 				"jsonrepair": "3.13.2",
 				"jssha": "3.3.1",
-				"lodash": "4.17.23",
+				"lodash": "4.18.1",
 				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"recast": "0.22.0",
 				"title-case": "3.0.3",
 				"transliteration": "2.3.5",
+				"uuid": "10.0.0",
 				"xml2js": "0.6.2",
 				"zod": "3.25.67"
 			}
@@ -12000,6 +12002,20 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.0.3",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- `ci.yml`: Added `pull-requests: write` — required for the nested `npm-audit-autofix.yml` job in `security-scan-source.yml`
- `security-scan.yml`: Added `pull-requests: write` and `contents: write` — fixes the validation error reported in the scheduled security scan

Depends on tehw0lf/workflows#63.