### PR TITLE
chore(package): bump version to 1.2.4 and update dev dependency

### DIFF
--- a/nodes/Toon/Toon.node.json
+++ b/nodes/Toon/Toon.node.json
@@ -11,6 +11,5 @@
 			}
 		]
 	},
-	"alias": ["JSON", "Data Format", "Conversion"],
-	"icon": "file:toon.svg"
+	"alias": ["JSON", "Data Format", "Conversion"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.2.3",
+			"version": "1.2.4",
 			"license": "MIT",
 			"devDependencies": {
-				"@n8n/node-cli": "^0.20.0",
+				"@n8n/node-cli": "^0.27.0",
 				"@types/jest": "30.0.0",
 				"eslint": "9.39.2",
 				"jest": "30.2.0",
@@ -20,6 +20,42 @@
 			"peerDependencies": {
 				"n8n-workflow": "^2.7.0"
 			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
+			"integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
@@ -544,6 +580,92 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@browserbasehq/sdk": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.10.0.tgz",
+			"integrity": "sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@browserbasehq/sdk/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@browserbasehq/sdk/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@browserbasehq/stagehand": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/stagehand/-/stagehand-1.14.0.tgz",
+			"integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.27.3",
+				"@browserbasehq/sdk": "^2.0.0",
+				"ws": "^8.18.0",
+				"zod-to-json-schema": "^3.23.5"
+			},
+			"peerDependencies": {
+				"@playwright/test": "^1.42.1",
+				"deepmerge": "^4.3.1",
+				"dotenv": "^16.4.5",
+				"openai": "^4.62.1",
+				"zod": "^3.23.8"
+			}
+		},
+		"node_modules/@browserbasehq/stagehand/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"node_modules/@cfworker/json-schema": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@clack/core": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
@@ -565,6 +687,32 @@
 				"@clack/core": "0.5.0",
 				"picocolors": "^1.0.0",
 				"sisteransi": "^1.0.5"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -919,6 +1067,43 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
 			}
+		},
+		"node_modules/@ibm-cloud/watsonx-ai": {
+			"version": "1.7.11",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.11.tgz",
+			"integrity": "sha512-sBMj/YhV5qvJdBpvgutmX6vLUUnSwvhFaJk7r3hiMh5aB7BQWQ+5zyzvSPLywOwTWZbgy4v8jxTUhR6jb+kguw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "^18.0.0",
+				"extend": "3.0.2",
+				"form-data": "^4.0.4",
+				"ibm-cloud-sdk-core": "^5.4.9",
+				"ts-node": "^10.9.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@ibm-cloud/watsonx-ai/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@ibm-cloud/watsonx-ai/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -2129,6 +2314,383 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@langchain/classic": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.5.tgz",
+			"integrity": "sha512-yMlcuQ80iG0SAEzgym95oLS+bJZJlmsFrMb+qkwg5mzHfL9DzAIFyvaMPiDnwKM0iv52u7iwD/aucLljZul9mQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/openai": "1.1.3",
+				"@langchain/textsplitters": "1.0.1",
+				"handlebars": "^4.7.8",
+				"js-yaml": "^4.1.1",
+				"jsonpointer": "^5.0.1",
+				"openapi-types": "^12.1.3",
+				"p-retry": "^7.0.0",
+				"uuid": "^10.0.0",
+				"yaml": "^2.2.1",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"langsmith": "^0.3.64"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0",
+				"cheerio": "*",
+				"peggy": "^3.0.2",
+				"typeorm": "*"
+			},
+			"peerDependenciesMeta": {
+				"cheerio": {
+					"optional": true
+				},
+				"peggy": {
+					"optional": true
+				},
+				"typeorm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/classic/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/core": {
+			"version": "1.1.41",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+			"integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@cfworker/json-schema": "^4.0.2",
+				"@standard-schema/spec": "^1.1.0",
+				"ansi-styles": "^5.0.0",
+				"camelcase": "6",
+				"decamelize": "1.2.0",
+				"js-tiktoken": "^1.0.12",
+				"langsmith": ">=0.5.0 <1.0.0",
+				"mustache": "^4.2.0",
+				"p-queue": "^6.6.2",
+				"uuid": "^11.1.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/langsmith": {
+			"version": "0.5.23",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.23.tgz",
+			"integrity": "sha512-dE/M/2Gg2S2R8ygDdkWGJVO3JstijvsNvPXsy9V8WGbpb88Zn8xF/aTjPx4mIy5gIoo02T6FssOgYyLf51Dv1Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/core/node_modules/langsmith/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/langgraph": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
+			"integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/langgraph-checkpoint": "^1.0.1",
+				"@langchain/langgraph-sdk": "~1.8.9",
+				"@standard-schema/spec": "1.1.0",
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.40",
+				"zod": "^3.25.32 || ^4.2.0",
+				"zod-to-json-schema": "^3.x"
+			},
+			"peerDependenciesMeta": {
+				"zod-to-json-schema": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/langgraph-checkpoint": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+			"integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.1"
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk": {
+			"version": "1.8.9",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
+			"integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15",
+				"p-queue": "^9.0.1",
+				"p-retry": "^7.1.1",
+				"uuid": "^13.0.0"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.16",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19",
+				"svelte": "^4.0.0 || ^5.0.0",
+				"vue": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@langchain/core": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+			"integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^5.0.1",
+				"p-timeout": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/@langchain/openai": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.1.3.tgz",
+			"integrity": "sha512-p+xR+4HRms5Ozjf5miC6U2AYRyNVSTdO7AMBkMYs1Tp6DWHBd+mQ72H8Ogd2dKrPuS5UDJ5dbpI1fS+OrTbgQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12",
+				"openai": "^6.9.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0"
+			}
+		},
+		"node_modules/@langchain/openai/node_modules/openai": {
+			"version": "6.34.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+			"integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/openai/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/textsplitters": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-1.0.1.tgz",
+			"integrity": "sha512-rheJlB01iVtrOUzttscutRgLybPH9qR79EyzBEbf1u97ljWyuxQfCwIWK+SjoQTM9O8M7GGLLRBSYE26Jmcoww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0"
+			}
+		},
 		"node_modules/@n8n_io/riot-tmpl": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
@@ -2137,6 +2699,807 @@
 			"peer": true,
 			"dependencies": {
 				"eslint-config-riot": "^1.0.0"
+			}
+		},
+		"node_modules/@n8n/ai-node-sdk": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.8.0.tgz",
+			"integrity": "sha512-LCLE/jJKwExEPPBHVVLEyyukQhrouv7TH17n9ApAAjHdDeuc+sIt6tyW43rCl3XbQKjCMIT+TtI5cf9ADdk5oQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/ai-utilities": "0.11.0"
+			}
+		},
+		"node_modules/@n8n/ai-utilities": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.11.0.tgz",
+			"integrity": "sha512-ILSdHgxKhPA9003wrsRdanFFIJZo8pWV4H70miWy4vo7+11LIc4nspUF0LQJup81xKrEj8vRJuxMWkeTNnEr7w==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@langchain/classic": "1.0.5",
+				"@langchain/community": "1.1.14",
+				"@langchain/core": "1.1.34",
+				"@langchain/openai": "1.1.3",
+				"@langchain/textsplitters": "1.0.1",
+				"@n8n/config": "2.16.0",
+				"@n8n/typescript-config": "1.4.0",
+				"https-proxy-agent": "7.0.6",
+				"js-tiktoken": "1.0.21",
+				"langchain": "1.2.30",
+				"proxy-from-env": "^1.1.0",
+				"tmp-promise": "3.0.3",
+				"undici": "^6.21.0",
+				"zod": "3.25.67",
+				"zod-to-json-schema": "3.23.3"
+			},
+			"peerDependencies": {
+				"n8n-workflow": "*"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.14.tgz",
+			"integrity": "sha512-Jb64jqkjwocfK04RYW8oP9Z0VO3E1LfSlOx5QK3g7LJI7zQN8o1QzVvfXWigKQRuvMYue+X7DkunLaiEx/mohA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/classic": "1.0.17",
+				"@langchain/openai": "1.2.7",
+				"binary-extensions": "^2.2.0",
+				"flat": "^5.0.2",
+				"js-yaml": "^4.1.1",
+				"math-expression-evaluator": "^2.0.0",
+				"uuid": "^10.0.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@arcjet/redact": "^v1.1.0",
+				"@aws-crypto/sha256-js": "^5.0.0",
+				"@aws-sdk/client-dynamodb": "^3.985.0",
+				"@aws-sdk/client-lambda": "^3.985.0",
+				"@aws-sdk/client-s3": "^3.985.0",
+				"@aws-sdk/client-sagemaker-runtime": "^3.985.0",
+				"@aws-sdk/client-sfn": "^3.985.0",
+				"@aws-sdk/credential-provider-node": "^3.388.0",
+				"@azure/search-documents": "^12.2.0",
+				"@azure/storage-blob": "^12.30.0",
+				"@browserbasehq/sdk": "*",
+				"@browserbasehq/stagehand": "^1.0.0",
+				"@clickhouse/client": "^0.2.5",
+				"@datastax/astra-db-ts": "^1.0.0",
+				"@elastic/elasticsearch": "^8.4.0",
+				"@getmetal/metal-sdk": "*",
+				"@getzep/zep-cloud": "^1.0.6",
+				"@getzep/zep-js": "^0.9.0",
+				"@gomomento/sdk-core": "^1.117.2",
+				"@google-cloud/storage": "^6.10.1 || ^7.7.0",
+				"@gradientai/nodejs-sdk": "^1.2.0",
+				"@huggingface/inference": "^4.13.11",
+				"@huggingface/transformers": "^3.8.1",
+				"@ibm-cloud/watsonx-ai": "*",
+				"@lancedb/lancedb": "^0.19.1",
+				"@langchain/core": "^1.1.21",
+				"@layerup/layerup-security": "^1.5.12",
+				"@libsql/client": "^0.17.0",
+				"@mendable/firecrawl-js": "^1.4.3",
+				"@mlc-ai/web-llm": "*",
+				"@mozilla/readability": "*",
+				"@neondatabase/serverless": "*",
+				"@notionhq/client": "^2.2.10",
+				"@opensearch-project/opensearch": "*",
+				"@planetscale/database": "^1.8.0",
+				"@premai/prem-sdk": "^0.3.25",
+				"@raycast/api": "^1.55.2",
+				"@rockset/client": "^0.9.1",
+				"@smithy/eventstream-codec": "^2.0.5",
+				"@smithy/protocol-http": "^3.0.6",
+				"@smithy/signature-v4": "^2.0.10",
+				"@smithy/util-utf8": "^2.0.0",
+				"@spider-cloud/spider-client": "^0.1.85",
+				"@supabase/supabase-js": "^2.45.0",
+				"@tensorflow-models/universal-sentence-encoder": "*",
+				"@tensorflow/tfjs-core": "*",
+				"@upstash/ratelimit": "^1.1.3 || ^2.0.3",
+				"@upstash/redis": "^1.20.6",
+				"@upstash/vector": "^1.1.1",
+				"@vercel/kv": "*",
+				"@vercel/postgres": "*",
+				"@writerai/writer-sdk": "^0.40.2",
+				"@xata.io/client": "^0.28.0",
+				"@zilliz/milvus2-sdk-node": ">=2.3.5",
+				"apify-client": "^2.22.0",
+				"assemblyai": "^4.23.0",
+				"azion": "^3.0.0",
+				"better-sqlite3": ">=9.4.0 <12.0.0",
+				"cassandra-driver": "^4.7.2",
+				"cborg": "^4.5.8",
+				"cheerio": "^1.0.0-rc.12",
+				"chromadb": "*",
+				"closevector-common": "0.1.3",
+				"closevector-node": "0.1.6",
+				"closevector-web": "0.1.6",
+				"convex": "^1.3.1",
+				"couchbase": "^4.6.0",
+				"crypto-js": "^4.2.0",
+				"d3-dsv": "^2.0.0",
+				"discord.js": "^14.25.1",
+				"duck-duck-scrape": "^2.2.5",
+				"epub2": "^3.0.1",
+				"faiss-node": "*",
+				"fast-xml-parser": "*",
+				"firebase-admin": "^13.6.1",
+				"google-auth-library": "*",
+				"googleapis": "*",
+				"hnswlib-node": "^3.0.0",
+				"html-to-text": "^9.0.5",
+				"ibm-cloud-sdk-core": "*",
+				"ignore": "^5.2.0",
+				"interface-datastore": "^8.2.11",
+				"ioredis": "^5.3.2",
+				"it-all": "^3.0.4",
+				"jsdom": "*",
+				"jsonwebtoken": "^9.0.3",
+				"lodash": "^4.17.23",
+				"lunary": "^0.7.10",
+				"mammoth": "^1.11.0",
+				"mariadb": "^3.4.0",
+				"mem0ai": "^2.1.8",
+				"mysql2": "^3.16.3",
+				"neo4j-driver": "*",
+				"node-llama-cpp": ">=3.0.0",
+				"notion-to-md": "^3.1.0",
+				"officeparser": "^4.0.4",
+				"openai": "*",
+				"pdf-parse": "1.1.1",
+				"pg": "^8.11.0",
+				"pg-copy-streams": "^6.0.5",
+				"pickleparser": "^0.2.1",
+				"playwright": "^1.58.2",
+				"portkey-ai": "^0.1.11",
+				"puppeteer": "*",
+				"pyodide": ">=0.24.1 <0.27.0",
+				"replicate": "*",
+				"sonix-speech-recognition": "^2.1.1",
+				"srt-parser-2": "^1.2.3",
+				"typeorm": "^0.3.28",
+				"typesense": "^3.0.1",
+				"usearch": "^1.1.1",
+				"voy-search": "0.6.2",
+				"word-extractor": "*",
+				"ws": "^8.14.2",
+				"youtubei.js": "*"
+			},
+			"peerDependenciesMeta": {
+				"@arcjet/redact": {
+					"optional": true
+				},
+				"@aws-crypto/sha256-js": {
+					"optional": true
+				},
+				"@aws-sdk/client-dynamodb": {
+					"optional": true
+				},
+				"@aws-sdk/client-lambda": {
+					"optional": true
+				},
+				"@aws-sdk/client-s3": {
+					"optional": true
+				},
+				"@aws-sdk/client-sagemaker-runtime": {
+					"optional": true
+				},
+				"@aws-sdk/client-sfn": {
+					"optional": true
+				},
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@aws-sdk/dsql-signer": {
+					"optional": true
+				},
+				"@azure/search-documents": {
+					"optional": true
+				},
+				"@azure/storage-blob": {
+					"optional": true
+				},
+				"@browserbasehq/sdk": {
+					"optional": true
+				},
+				"@clickhouse/client": {
+					"optional": true
+				},
+				"@datastax/astra-db-ts": {
+					"optional": true
+				},
+				"@elastic/elasticsearch": {
+					"optional": true
+				},
+				"@getmetal/metal-sdk": {
+					"optional": true
+				},
+				"@getzep/zep-cloud": {
+					"optional": true
+				},
+				"@getzep/zep-js": {
+					"optional": true
+				},
+				"@gomomento/sdk-core": {
+					"optional": true
+				},
+				"@google-cloud/storage": {
+					"optional": true
+				},
+				"@gradientai/nodejs-sdk": {
+					"optional": true
+				},
+				"@huggingface/inference": {
+					"optional": true
+				},
+				"@huggingface/transformers": {
+					"optional": true
+				},
+				"@lancedb/lancedb": {
+					"optional": true
+				},
+				"@layerup/layerup-security": {
+					"optional": true
+				},
+				"@libsql/client": {
+					"optional": true
+				},
+				"@mendable/firecrawl-js": {
+					"optional": true
+				},
+				"@mlc-ai/web-llm": {
+					"optional": true
+				},
+				"@mozilla/readability": {
+					"optional": true
+				},
+				"@neondatabase/serverless": {
+					"optional": true
+				},
+				"@notionhq/client": {
+					"optional": true
+				},
+				"@opensearch-project/opensearch": {
+					"optional": true
+				},
+				"@pinecone-database/pinecone": {
+					"optional": true
+				},
+				"@planetscale/database": {
+					"optional": true
+				},
+				"@premai/prem-sdk": {
+					"optional": true
+				},
+				"@qdrant/js-client-rest": {
+					"optional": true
+				},
+				"@raycast/api": {
+					"optional": true
+				},
+				"@rockset/client": {
+					"optional": true
+				},
+				"@smithy/eventstream-codec": {
+					"optional": true
+				},
+				"@smithy/protocol-http": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
+				"@smithy/util-utf8": {
+					"optional": true
+				},
+				"@spider-cloud/spider-client": {
+					"optional": true
+				},
+				"@supabase/supabase-js": {
+					"optional": true
+				},
+				"@tensorflow-models/universal-sentence-encoder": {
+					"optional": true
+				},
+				"@tensorflow/tfjs-core": {
+					"optional": true
+				},
+				"@upstash/ratelimit": {
+					"optional": true
+				},
+				"@upstash/redis": {
+					"optional": true
+				},
+				"@upstash/vector": {
+					"optional": true
+				},
+				"@vercel/kv": {
+					"optional": true
+				},
+				"@vercel/postgres": {
+					"optional": true
+				},
+				"@writerai/writer-sdk": {
+					"optional": true
+				},
+				"@xata.io/client": {
+					"optional": true
+				},
+				"@xenova/transformers": {
+					"optional": true
+				},
+				"@zilliz/milvus2-sdk-node": {
+					"optional": true
+				},
+				"apify-client": {
+					"optional": true
+				},
+				"assemblyai": {
+					"optional": true
+				},
+				"azion": {
+					"optional": true
+				},
+				"better-sqlite3": {
+					"optional": true
+				},
+				"cassandra-driver": {
+					"optional": true
+				},
+				"cborg": {
+					"optional": true
+				},
+				"cheerio": {
+					"optional": true
+				},
+				"chromadb": {
+					"optional": true
+				},
+				"closevector-common": {
+					"optional": true
+				},
+				"closevector-node": {
+					"optional": true
+				},
+				"closevector-web": {
+					"optional": true
+				},
+				"cohere-ai": {
+					"optional": true
+				},
+				"convex": {
+					"optional": true
+				},
+				"couchbase": {
+					"optional": true
+				},
+				"crypto-js": {
+					"optional": true
+				},
+				"d3-dsv": {
+					"optional": true
+				},
+				"discord.js": {
+					"optional": true
+				},
+				"duck-duck-scrape": {
+					"optional": true
+				},
+				"epub2": {
+					"optional": true
+				},
+				"faiss-node": {
+					"optional": true
+				},
+				"fast-xml-parser": {
+					"optional": true
+				},
+				"firebase-admin": {
+					"optional": true
+				},
+				"google-auth-library": {
+					"optional": true
+				},
+				"googleapis": {
+					"optional": true
+				},
+				"hnswlib-node": {
+					"optional": true
+				},
+				"html-to-text": {
+					"optional": true
+				},
+				"ignore": {
+					"optional": true
+				},
+				"interface-datastore": {
+					"optional": true
+				},
+				"ioredis": {
+					"optional": true
+				},
+				"it-all": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"jsonwebtoken": {
+					"optional": true
+				},
+				"lodash": {
+					"optional": true
+				},
+				"lunary": {
+					"optional": true
+				},
+				"mammoth": {
+					"optional": true
+				},
+				"mariadb": {
+					"optional": true
+				},
+				"mem0ai": {
+					"optional": true
+				},
+				"mongodb": {
+					"optional": true
+				},
+				"mysql2": {
+					"optional": true
+				},
+				"neo4j-driver": {
+					"optional": true
+				},
+				"node-llama-cpp": {
+					"optional": true
+				},
+				"notion-to-md": {
+					"optional": true
+				},
+				"officeparser": {
+					"optional": true
+				},
+				"pdf-parse": {
+					"optional": true
+				},
+				"pg": {
+					"optional": true
+				},
+				"pg-copy-streams": {
+					"optional": true
+				},
+				"pickleparser": {
+					"optional": true
+				},
+				"playwright": {
+					"optional": true
+				},
+				"portkey-ai": {
+					"optional": true
+				},
+				"puppeteer": {
+					"optional": true
+				},
+				"pyodide": {
+					"optional": true
+				},
+				"redis": {
+					"optional": true
+				},
+				"replicate": {
+					"optional": true
+				},
+				"sonix-speech-recognition": {
+					"optional": true
+				},
+				"srt-parser-2": {
+					"optional": true
+				},
+				"typeorm": {
+					"optional": true
+				},
+				"typesense": {
+					"optional": true
+				},
+				"usearch": {
+					"optional": true
+				},
+				"voy-search": {
+					"optional": true
+				},
+				"weaviate-client": {
+					"optional": true
+				},
+				"word-extractor": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				},
+				"youtubei.js": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/classic": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.17.tgz",
+			"integrity": "sha512-GgcmDILxl26E0Oo09Q/fotJB3EZrTnU4MuJGR2zQXPMZnZ1CCQqyecXjKDRdI6sZkfc8Kxg+ezT+0kIMtKV10A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/openai": "1.2.7",
+				"@langchain/textsplitters": "1.0.1",
+				"handlebars": "^4.7.8",
+				"js-yaml": "^4.1.1",
+				"jsonpointer": "^5.0.1",
+				"openapi-types": "^12.1.3",
+				"uuid": "^10.0.0",
+				"yaml": "^2.2.1",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"langsmith": ">=0.4.0 <1.0.0"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0",
+				"cheerio": "*",
+				"peggy": "^3.0.2",
+				"typeorm": "*"
+			},
+			"peerDependenciesMeta": {
+				"cheerio": {
+					"optional": true
+				},
+				"peggy": {
+					"optional": true
+				},
+				"typeorm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/classic/node_modules/langsmith": {
+			"version": "0.5.23",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.23.tgz",
+			"integrity": "sha512-dE/M/2Gg2S2R8ygDdkWGJVO3JstijvsNvPXsy9V8WGbpb88Zn8xF/aTjPx4mIy5gIoo02T6FssOgYyLf51Dv1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.2.7.tgz",
+			"integrity": "sha512-vR9zoF0/EZ03X0Tc6woIEWRDSDSr2l64n+MQCW8NduScJtBJs5r/Ng3Lrp2bjtJQywEMQoOhcrV2DMmAIPWgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12",
+				"openai": "^6.18.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
+			"version": "6.34.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+			"integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core": {
+			"version": "1.1.34",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.34.tgz",
+			"integrity": "sha512-IDlZES5Vexo5meLQRCGkAU7NM0tPGPfPP5wcUzBd7Ot+JoFBmSXutC4gGzvZod5AKRVn3I0Qy5k8vkTraY21jA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cfworker/json-schema": "^4.0.2",
+				"@standard-schema/spec": "^1.1.0",
+				"ansi-styles": "^5.0.0",
+				"camelcase": "6",
+				"decamelize": "1.2.0",
+				"js-tiktoken": "^1.0.12",
+				"langsmith": ">=0.5.0 <1.0.0",
+				"mustache": "^4.2.0",
+				"p-queue": "^6.6.2",
+				"uuid": "^11.1.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith": {
+			"version": "0.5.23",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.23.tgz",
+			"integrity": "sha512-dE/M/2Gg2S2R8ygDdkWGJVO3JstijvsNvPXsy9V8WGbpb88Zn8xF/aTjPx4mIy5gIoo02T6FssOgYyLf51Dv1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@n8n/config": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.16.0.tgz",
+			"integrity": "sha512-38EkGsk1Kg6erpAkaJT+XNLp6okqc4wcmeeGoEuz0LDkcxnF1uE/yu6dmkhlkvP8YWWZiE9b0Pzk2X6UDFaPCw==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/di": "0.10.0",
+				"reflect-metadata": "0.2.2",
+				"zod": "3.25.67"
+			}
+		},
+		"node_modules/@n8n/di": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.10.0.tgz",
+			"integrity": "sha512-wqVjmb/tfE1Dyax6607K5InLM89pHZvmVTfakv6y17XJSwu2JbkT/+FI1z2tQswoSlhBIH3N1BZSiYsVbP58bw==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"reflect-metadata": "0.2.2"
 			}
 		},
 		"node_modules/@n8n/errors": {
@@ -2150,9 +3513,9 @@
 			}
 		},
 		"node_modules/@n8n/eslint-plugin-community-nodes": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.7.0.tgz",
-			"integrity": "sha512-Mc4d1jTvvXXtddxqZwGCnG747osrFfDls9AHeDFywQJGMBAIT5D6NQP/7A5X/qWNZHAkATP6xsMWhl5o6pTX8w==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.12.0.tgz",
+			"integrity": "sha512-HgY3D7HJtfQOcjoMg8oyBj6agFJKkAuW6EQlk5mHd5YCPFKyY1oQLeVsl20gE+Cl0DsR2s9r8jFirLdpGFG+ng==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -2160,7 +3523,8 @@
 				"fastest-levenshtein": "1.0.16"
 			},
 			"peerDependencies": {
-				"eslint": ">= 9"
+				"eslint": ">= 9",
+				"n8n-workflow": ">=2"
 			}
 		},
 		"node_modules/@n8n/expression-runtime": {
@@ -2183,21 +3547,22 @@
 			}
 		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.20.0.tgz",
-			"integrity": "sha512-Zuuj7KhV3/syt7YbiZA8Wj06z2wBsplt+oRhRSzSp76tuwREm+Qgg78fhF+5d/jMyv+f8dde+IHCTiE+ppFCww==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.27.0.tgz",
+			"integrity": "sha512-YFbz0qThHcDUtmtDhwsb0SLr5LWledc5UMfujUr7GFSiw2lcVdfyj+FfCfw4mYADKE1780TEkg+E1BlyYZwxRQ==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/eslint-plugin-community-nodes": "0.7.0",
+				"@n8n/ai-node-sdk": "0.8.0",
+				"@n8n/eslint-plugin-community-nodes": "0.12.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
 				"eslint-import-resolver-typescript": "^4.4.3",
 				"eslint-plugin-import-x": "^4.15.2",
 				"eslint-plugin-n8n-nodes-base": "1.16.5",
 				"fast-glob": "3.2.12",
-				"handlebars": "4.7.8",
+				"handlebars": "4.7.9",
 				"picocolors": "1.0.1",
 				"prettier": "3.6.2",
 				"prompts": "^2.4.2",
@@ -2210,28 +3575,6 @@
 			},
 			"peerDependencies": {
 				"eslint": ">= 9"
-			}
-		},
-		"node_modules/@n8n/node-cli/node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.2",
-				"source-map": "^0.6.1",
-				"wordwrap": "^1.0.0"
-			},
-			"bin": {
-				"handlebars": "bin/handlebars"
-			},
-			"engines": {
-				"node": ">=0.4.7"
-			},
-			"optionalDependencies": {
-				"uglify-js": "^3.1.4"
 			}
 		},
 		"node_modules/@n8n/node-cli/node_modules/prettier": {
@@ -2266,6 +3609,13 @@
 				"node": ">=20.15",
 				"pnpm": ">=9.5"
 			}
+		},
+		"node_modules/@n8n/typescript-config": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.4.0.tgz",
+			"integrity": "sha512-HC2rgU/FtbOb6vpC/VvqfOxqeMkmQH/YdZK1y/wel7YgMCJcv92IhjJPehW1Qpp+OUesGTn03VJb4vee/ZEBkw==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -2379,6 +3729,23 @@
 				"url": "https://opencollective.com/pkgr"
 			}
 		},
+		"node_modules/@playwright/test": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"playwright": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.34.49",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -2406,6 +3773,40 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@ts-morph/common": {
 			"version": "0.28.1",
 			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -2417,6 +3818,38 @@
 				"path-browserify": "^1.0.1",
 				"tinyglobby": "^0.2.14"
 			}
+		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
@@ -2474,6 +3907,17 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2526,6 +3970,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/node": {
 			"version": "25.6.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -2534,6 +3986,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.19.0"
+			}
+		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.13",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+			"integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^4.0.4"
 			}
 		},
 		"node_modules/@types/semver": {
@@ -2549,6 +4013,22 @@
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.35",
@@ -3110,6 +4590,20 @@
 				"win32"
 			]
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3131,6 +4625,44 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/agentkeepalive": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -3218,6 +4750,14 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3290,6 +4830,48 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/axios": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/axios/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -3401,6 +4983,27 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.21",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
@@ -3412,6 +5015,19 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -3496,6 +5112,14 @@
 			"dependencies": {
 				"node-int64": "^0.4.0"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
@@ -3822,12 +5446,31 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/console-table-printer": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+			"integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"simple-wcswidth": "^1.1.2"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3870,6 +5513,16 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/dedent": {
@@ -3960,6 +5613,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/diff": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3987,6 +5651,20 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4008,6 +5686,17 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
@@ -4983,6 +6672,24 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5041,6 +6748,14 @@
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -5136,6 +6851,26 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
 		"node_modules/filelist": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -5206,6 +6941,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5226,6 +6971,28 @@
 			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/for-each": {
 			"version": "0.3.5",
@@ -5275,6 +7042,29 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data-encoder": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+			"integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/formdata-node": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+			"integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "1.0.0",
+				"web-streams-polyfill": "4.0.0-beta.3"
+			},
+			"engines": {
+				"node": ">= 12.20"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -5637,6 +7427,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5646,6 +7450,101 @@
 			"engines": {
 				"node": ">=10.17.0"
 			}
+		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core": {
+			"version": "5.4.12",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.12.tgz",
+			"integrity": "sha512-aBi9U/HENeKOpI1pzFp8/gQY/ao2DeJoCH/KZxP0Vk6864k5e2JYmbU03Jlbc3qxjsCwdNmmCsK8BgSqHzYjSg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.19.80",
+				"@types/tough-cookie": "^4.0.0",
+				"axios": "1.15.2",
+				"camelcase": "^6.3.0",
+				"debug": "^4.3.4",
+				"dotenv": "^16.4.5",
+				"extend": "3.0.2",
+				"file-type": "^21.3.2",
+				"form-data": "^4.0.4",
+				"isstream": "0.1.2",
+				"jsonwebtoken": "^9.0.3",
+				"load-esm": "^1.0.3",
+				"mime-types": "2.1.35",
+				"retry-axios": "^2.6.0",
+				"tough-cookie": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -5891,6 +7790,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-network-error": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+			"integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5993,6 +7905,14 @@
 			"engines": {
 				"node": ">=22.0.0"
 			}
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -7654,6 +9574,16 @@
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
+		"node_modules/js-tiktoken": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+			"integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.5.1"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7728,6 +9658,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonpointer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+			"integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/jsonrepair": {
 			"version": "3.13.2",
 			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.2.tgz",
@@ -7738,6 +9678,30 @@
 				"jsonrepair": "bin/cli.js"
 			}
 		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/jssha": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
@@ -7746,6 +9710,31 @@
 			"peer": true,
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/keyv": {
@@ -7766,6 +9755,135 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/langchain": {
+			"version": "1.2.30",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.30.tgz",
+			"integrity": "sha512-Ofsk7LTGvIkyy3uesv7hpyerpTghdjNpYFJfIxJRGGLjd+4JgTVkT/Ax6Cjg0F6doEuO7VRID0NK2QwmT3A/bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/langgraph": "^1.1.2",
+				"@langchain/langgraph-checkpoint": "^1.0.0",
+				"langsmith": ">=0.5.0 <1.0.0",
+				"uuid": "^11.1.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.31"
+			}
+		},
+		"node_modules/langchain/node_modules/langsmith": {
+			"version": "0.5.23",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.23.tgz",
+			"integrity": "sha512-dE/M/2Gg2S2R8ygDdkWGJVO3JstijvsNvPXsy9V8WGbpb88Zn8xF/aTjPx4mIy5gIoo02T6FssOgYyLf51Dv1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/langchain/node_modules/langsmith/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/langchain/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/langchain/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/langsmith": {
+			"version": "0.3.87",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+			"integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^4.1.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/leven": {
@@ -7812,6 +9930,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/load-esm": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+			"integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/Borewit"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://buymeacoffee.com/borewit"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=13.2.0"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7835,6 +9974,54 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7848,6 +10035,14 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lower-case": {
 			"version": "2.0.2",
@@ -7911,6 +10106,13 @@
 			"dependencies": {
 				"tmpl": "1.0.5"
 			}
+		},
+		"node_modules/math-expression-evaluator": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-2.0.7.tgz",
+			"integrity": "sha512-uwliJZ6BPHRq4eiqNWxZBDzKUiS5RIynFFcgchqhBOloVLVBpZpNG8jRYkedLcBvhph8TnRyWEuxPqiQcwIdog==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -8041,6 +10243,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mustache": "bin/mustache"
+			}
+		},
 		"node_modules/n8n-workflow": {
 			"version": "2.18.2",
 			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.18.2.tgz",
@@ -8111,6 +10323,50 @@
 			"dependencies": {
 				"lower-case": "^2.0.2",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -8236,6 +10492,64 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/openai": {
+			"version": "4.104.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+			"integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			},
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.23.8"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openai/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/openai/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/openapi-types": {
+			"version": "12.1.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8252,6 +10566,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
@@ -8284,6 +10608,52 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-queue": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^4.0.4",
+				"p-timeout": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+			"integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-network-error": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-finally": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-try": {
@@ -8516,6 +10886,56 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/pluralize": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -8604,6 +11024,27 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8630,6 +11071,14 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -8689,6 +11138,13 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/reflect-metadata": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8697,6 +11153,14 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/resolve-cwd": {
 			"version": "3.0.0",
@@ -8739,6 +11203,20 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/retry-axios": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+			"integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=10.7.0"
+			},
+			"peerDependencies": {
+				"axios": "*"
 			}
 		},
 		"node_modules/reusify": {
@@ -8874,6 +11352,28 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -8980,6 +11480,14 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/simple-wcswidth": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+			"integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
@@ -9242,6 +11750,24 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -9407,6 +11933,26 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/tmp-promise": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tmp": "^0.2.0"
+			}
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -9426,6 +11972,51 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/transliteration": {
 			"version": "2.3.5",
@@ -9534,6 +12125,51 @@
 				"code-block-writer": "^13.0.3"
 			}
 		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -9628,12 +12264,47 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+			"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "7.19.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
 			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/unrs-resolver": {
 			"version": "1.11.1",
@@ -9728,6 +12399,18 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"node_modules/util": {
 			"version": "0.12.5",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -9751,10 +12434,17 @@
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.3.0",
@@ -9779,6 +12469,37 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"makeerror": "1.0.12"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "4.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+			"integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -9950,6 +12671,29 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/xml2js": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -9990,6 +12734,22 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -10017,6 +12777,17 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -10035,9 +12806,18 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
 			"integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.23.3",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+			"integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.23.3"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.0.3",
 	"license": "MIT",
@@ -46,7 +46,7 @@
 		]
 	},
 	"devDependencies": {
-		"@n8n/node-cli": "^0.20.0",
+		"@n8n/node-cli": "^0.27.0",
 		"@types/jest": "30.0.0",
 		"eslint": "9.39.2",
 		"jest": "30.2.0",


### PR DESCRIPTION
* Updated package version from `1.2.3` to `1.2.4`.
* Upgraded `@n8n/node-cli` from `^0.20.0` to `^0.27.0` to incorporate the latest features and improvements.
