### PR TITLE
fix(lint): add subtitle property and wrap raw error in NodeOperationError

### DIFF
--- a/nodes/Toon/Toon.node.ts
+++ b/nodes/Toon/Toon.node.ts
@@ -24,6 +24,7 @@ export class Toon implements INodeType {
     group: ['transform'],
     version: 1,
     description: 'Convert between TOON and JSON formats with zero external dependencies',
+    subtitle: '={{$parameter["operation"]}}',
     defaults: {
       name: 'TOON',
     },
@@ -270,10 +271,6 @@ export class Toon implements INodeType {
             pairedItem: { item: itemIndex },
           });
         } else {
-          if (error.context) {
-            error.context.itemIndex = itemIndex;
-            throw error;
-          }
           throw new NodeOperationError(this.getNode(), error as Error, {
             itemIndex,
           });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.2.4",
+			"version": "1.2.5",
 			"license": "MIT",
 			"devDependencies": {
-				"@n8n/node-cli": "^0.30.0",
+				"@n8n/node-cli": "^0.30.1",
 				"@types/jest": "30.0.0",
 				"eslint": "9.39.2",
 				"jest": "30.2.0",
@@ -2374,9 +2374,9 @@
 			}
 		},
 		"node_modules/@langchain/classic/node_modules/openai": {
-			"version": "6.36.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.36.0.tgz",
-			"integrity": "sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==",
+			"version": "6.37.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+			"integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2406,9 +2406,9 @@
 			}
 		},
 		"node_modules/@langchain/core": {
-			"version": "1.1.44",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.44.tgz",
-			"integrity": "sha512-RePW1IjGCHr9ua2vcby3aE8mOOz3EnwDZxMEGbNDT91kf14eqkJqxDXvaZFviGdcN9DTrxM5RPQNAHmwSm4tbg==",
+			"version": "1.1.45",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.45.tgz",
+			"integrity": "sha512-Y/wvuglLTMKJahkl4QD9dBIdF/z/CxZJWdTfHJF/q2jtlJtoFf6Mb5JpGxZfsi3mBY6NSG941FSLTcqhCKrhBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2611,9 +2611,9 @@
 			}
 		},
 		"node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.36.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.36.0.tgz",
-			"integrity": "sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==",
+			"version": "6.37.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+			"integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2676,19 +2676,19 @@
 			}
 		},
 		"node_modules/@n8n/ai-node-sdk": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.11.0.tgz",
-			"integrity": "sha512-eW2vz13kY2U1ZnJegMDIeUjWnN578O76W/ZKSON3JB+Zn4SIQ1rIt/oCf/9JMIPsIJrAu+86oZz1fc2RvlilRw==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.11.1.tgz",
+			"integrity": "sha512-De5Dy+yONKA8GeVE/UWBMmS4PVoxOlyX0fqSjp7vFnLqhKpdmQSk33eQH6tdZcOTVfZxl4P0WnLfJYBRRkpixg==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/ai-utilities": "0.14.0"
+				"@n8n/ai-utilities": "0.14.1"
 			}
 		},
 		"node_modules/@n8n/ai-utilities": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.14.0.tgz",
-			"integrity": "sha512-DYfvfVTLjLtia7vQAk17soWb8ScOsIsts+A+Lhlbh42IdmA3d9hTxO3HANlxvF/WGfHf9vR7SP9eMKaQWZkrZA==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.14.1.tgz",
+			"integrity": "sha512-n5K5CjauxRNoc2sIX+fVICl4Z8LaO9jBwaP48/XWh6ckUj2JzQ05D52YFr7Y7g/j5h56AJgNb7UCv8+EqpCcWA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -2697,7 +2697,7 @@
 				"@langchain/core": "1.1.41",
 				"@langchain/openai": "1.4.4",
 				"@langchain/textsplitters": "1.0.1",
-				"@n8n/config": "2.19.0",
+				"@n8n/config": "2.19.1",
 				"@n8n/typescript-config": "1.4.0",
 				"https-proxy-agent": "7.0.6",
 				"js-tiktoken": "1.0.21",
@@ -3225,9 +3225,9 @@
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.36.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.36.0.tgz",
-			"integrity": "sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==",
+			"version": "6.37.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+			"integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -3330,9 +3330,9 @@
 			}
 		},
 		"node_modules/@n8n/config": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.19.0.tgz",
-			"integrity": "sha512-YkCUKTZ82oN2mBH2Kk5puJuH47t2IE344Ku+H9L1jkziPjBcEnEQ41BfGtEGVwdzDpwVv0Vtt0IFDLDXkgq1TA==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.19.1.tgz",
+			"integrity": "sha512-4D3UV7ArTfN/G4GN5kCRHBD7ELplNN6rgySTbiv2XR0PrUpmYZBtkjSdDp0GafbQUu7h8CAB9qdnk8FUWx8krA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -3396,14 +3396,14 @@
 			}
 		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.30.0.tgz",
-			"integrity": "sha512-II1NBVe+IE+j/G8IYjBCVi4N8eUuO6NdeJoZ2SnFEVDOxKTkTOd0RtvjgjSbD8fGi+u8TTwW0pKTDaI8qhNLJQ==",
+			"version": "0.30.1",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.30.1.tgz",
+			"integrity": "sha512-upshbVjRQl/V3YRkoLeO/Y8giEcBOIPT7N2+U6jaftNGpVxTlHcPtZvMr1bPMQ0iDlSNUpOBB3tbWD4t4V/Tfg==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/ai-node-sdk": "0.11.0",
+				"@n8n/ai-node-sdk": "0.11.1",
 				"@n8n/eslint-plugin-community-nodes": "0.15.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
@@ -9649,9 +9649,9 @@
 			}
 		},
 		"node_modules/langsmith": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.1.tgz",
-			"integrity": "sha512-qNBNPRFqScIlGaPGfMrxhw/GTOL4GJKMp1P4jeA3xuI+Gkj5Ei3wvOtxpYaZMTeBbXTW3yi4n4Wf3nCgogvttg==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.2.tgz",
+			"integrity": "sha512-OrFt+a2P4UMaa2cSpp3fjYTJ+TWQFjnoz5j4njiZYWMpAJezTrMRN1mrNVzq/FACprgPwAMjq5YkZNRYJKorwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.0.3",
 	"license": "MIT",
@@ -46,7 +46,7 @@
 		]
 	},
 	"devDependencies": {
-		"@n8n/node-cli": "^0.30.0",
+		"@n8n/node-cli": "^0.30.1",
 		"@types/jest": "30.0.0",
 		"eslint": "9.39.2",
 		"jest": "30.2.0",


### PR DESCRIPTION
## Summary
- Add missing `subtitle` property to node description (fixes `require-node-description-fields`)
- Remove raw error re-throw and always wrap via `NodeOperationError` (fixes `require-node-api-error`)

## Test plan
- [x] `npm run lint` passes cleanly
- [x] `npm run test` — 179 tests passing
- [x] `npm run build` successful