### PR TITLE
feat: implement TOON spec v3.3.0

### DIFF
--- a/.github/workflows/monitor-spec.yml
+++ b/.github/workflows/monitor-spec.yml
@@ -184,14 +184,26 @@ jobs:
                 issue_number: existingIssue.number,
                 body: `🔄 **Reminder:** This specification update is still pending.\n\nLast checked: ${new Date().toISOString()}`
               });
+
+              // Assign if not already assigned
+              const alreadyAssigned = existingIssue.assignees.some(a => a.login === context.repo.owner);
+              if (!alreadyAssigned) {
+                await github.rest.issues.addAssignees({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existingIssue.number,
+                  assignees: [context.repo.owner]
+                });
+              }
             } else {
-              // Create a new issue
+              // Create a new issue and assign the repo owner
               const issue = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: issueTitle,
                 body: issueBody,
-                labels: ['spec-update', 'enhancement']
+                labels: ['spec-update', 'enhancement'],
+                assignees: [context.repo.owner]
               });
 
               console.log(`Created issue #${issue.data.number}`);

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,9 +2,9 @@
 
 ## Token-Oriented Object Notation
 
-**Version:** 3.0
+**Version:** 3.3
 
-**Date:** 2025-11-24
+**Date:** 2026-05-21
 
 **Status:** Working Draft
 
@@ -16,11 +16,11 @@
 
 ## Abstract
 
-Token-Oriented Object Notation (TOON) is a line-oriented, indentation-based text format that encodes the JSON data model with explicit structure and minimal quoting. Arrays declare their length and an optional field list once; rows use a single active delimiter (comma, tab, or pipe). Objects use indentation instead of braces; strings are quoted only when required. This specification defines TOON’s concrete syntax, canonical number formatting, delimiter scoping, and strict‑mode validation, and sets conformance requirements for encoders, decoders, and validators. TOON provides a compact, deterministic representation of structured data and is particularly efficient for arrays of uniform objects.
+Token-Oriented Object Notation (TOON) is a line-oriented, indentation-based text format that encodes the JSON data model with explicit structure and minimal quoting. Arrays declare their length and an optional field list once; rows use a single active delimiter (comma, tab, or pipe). Objects use indentation instead of braces; strings are quoted only when required. This specification defines TOON's concrete syntax, canonical number formatting, delimiter scoping, and strict-mode validation, and sets conformance requirements for encoders, decoders, and validators. TOON provides a deterministic representation of structured data, with tabular syntax for arrays of uniform objects.
 
 ## Status of This Document
 
-This document is a Working Draft v3.0 and may be updated, replaced, or obsoleted. Implementers should monitor the canonical repository at https://github.com/toon-format/spec for changes.
+This document is a Working Draft v3.3 and may be updated, replaced, or obsoleted. Implementers should monitor the canonical repository at https://github.com/toon-format/spec for changes.
 
 This specification is stable for implementation but not yet finalized. Breaking changes may occur in future major versions.
 
@@ -57,7 +57,7 @@ https://www.iso.org/standard/70907.html
 
 ## Table of Contents
 
-- [Introduction](#introduction)
+- [Introduction](#introduction-informative)
 1. [Terminology and Conventions](#1-terminology-and-conventions)
 2. [Data Model](#2-data-model)
 3. [Encoding Normalization (Reference Encoder)](#3-encoding-normalization-reference-encoder)
@@ -74,11 +74,9 @@ https://www.iso.org/standard/70907.html
 14. [Strict Mode Errors and Diagnostics (Authoritative Checklist)](#14-strict-mode-errors-and-diagnostics-authoritative-checklist)
 15. [Security Considerations](#15-security-considerations)
 16. [Internationalization](#16-internationalization)
-17. [Interoperability and Mappings (Informative)](#17-interoperability-and-mappings-informative)
-18. [IANA Considerations](#18-iana-considerations)
-19. [TOON Core Profile (Normative Subset)](#19-toon-core-profile-normative-subset)
-20. [Versioning and Extensibility](#20-versioning-and-extensibility)
-21. [Intellectual Property Considerations](#21-intellectual-property-considerations)
+17. [IANA Considerations](#17-iana-considerations)
+18. [Versioning and Extensibility](#18-versioning-and-extensibility)
+19. [Intellectual Property Considerations](#19-intellectual-property-considerations)
 
 **Appendices:**
 - [Appendix A: Examples (Informative)](#appendix-a-examples-informative)
@@ -86,16 +84,15 @@ https://www.iso.org/standard/70907.html
 - [Appendix C: Test Suite and Compliance (Informative)](#appendix-c-test-suite-and-compliance-informative)
 - [Appendix D: Document Changelog (Informative)](#appendix-d-document-changelog-informative)
 - [Appendix E: Acknowledgments and License](#appendix-e-acknowledgments-and-license)
-- [Appendix F: Cross-check With Reference Behavior (Informative)](#appendix-f-cross-check-with-reference-behavior-informative)
-- [Appendix G: Host Type Normalization Examples (Informative)](#appendix-g-host-type-normalization-examples-informative)
+- [Appendix F: Host Type Normalization Examples (Informative)](#appendix-f-host-type-normalization-examples-informative)
 
 ## Introduction (Informative)
 
 ### Purpose and scope
 
-TOON (Token-Oriented Object Notation) is a line-oriented, indentation-based text format that encodes the JSON data model with explicit structure and minimal quoting. It is designed as a compact, deterministic representation of structured data, particularly well-suited to arrays of uniform objects. TOON is often used as a translation layer: produce data as JSON in code, encode to TOON for downstream consumption (e.g., LLM prompts), and decode back to JSON if needed.
+TOON is a token-efficient text format for JSON-shaped data, designed primarily for LLM prompts and contexts where every token costs. It saves tokens vs JSON by declaring array shapes once (length and optional field list) and using indentation in place of braces. TOON is typically used as a translation layer: produce data as JSON in code, encode to TOON for downstream consumption, and decode back to JSON if needed.
 
-### Applicability and non‑goals
+### Applicability and non-goals
 
 Use TOON when:
 - arrays of objects share the same fields (uniform tabular data),
@@ -105,7 +102,7 @@ Use TOON when:
 
 TOON is not intended to replace:
 - JSON for non-uniform or deeply nested structures where repeated keys are not dominant,
-- CSV for flat, strictly tabular data where maximum compactness is required and nesting is not needed,
+- CSV for flat, strictly tabular data without nesting,
 - general-purpose storage or public APIs. TOON carries the JSON data model; it is a transport/authoring format with explicit structure, not an extended type system or schema language.
 
 Out of scope:
@@ -116,7 +113,7 @@ Out of scope:
 ### Relationship to JSON, CSV, and YAML (Informative)
 
 - **JSON**: TOON preserves the JSON data model. It is more compact for uniform arrays of objects by declaring length and fields once. For non-uniform or deeply nested data, JSON may be more efficient.
-- **CSV/TSV**: CSV is typically more compact for flat tables but lacks nesting and type awareness. TOON adds explicit lengths, per-array delimiter scoping, field lists, and deterministic quoting, while remaining lightweight.
+- **CSV/TSV**: CSV is typically more compact for flat tables but lacks nesting and type awareness. TOON adds explicit lengths, per-array delimiter scoping, inline field lists (no separate header row), and deterministic quoting, while remaining lightweight.
 - **YAML**: TOON uses indentation and hyphen markers but is more constrained and deterministic: no comments, explicit array headers with lengths, fixed quoting rules, and a narrow escape set.
 
 ### Example (Informative)
@@ -127,33 +124,18 @@ users[2]{id,name,role}:
   2,Bob,user
 ```
 
-### Document roadmap
-
-Normative rules are organized as follows:
-- Data model and canonical number form (§2); normalization on encode (§3); decoding interpretation (§4).
-- Concrete syntax, including root-form determination (§5) and header syntax (§6).
-- Strings and keys (§7); objects (§8); arrays and their sub-forms (§9); objects as list items (§10); delimiter rules (§11).
-- Indentation and whitespace (§12); conformance and options (§13).
-- Strict-mode errors (authoritative checklist) (§14).
-
-Appendices are informative unless stated otherwise and provide examples, parsing helpers, and implementation guidance.
-
 ## 1. Terminology and Conventions
 
 ### 1.1 Use of RFC2119 Keywords and Normativity
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119] and [RFC8174] when, and only when, they appear in all capitals, as shown here.
 
-Audience: implementers of encoders/decoders/validators; tool authors; practitioners embedding TOON in LLM prompts.
-
-All normative text in this specification is contained in Sections 1-16 and Section 19. All appendices are informative except where explicitly marked normative. Examples throughout this document are informative unless explicitly stated otherwise.
-
-Implementations that fail to conform to any MUST or REQUIRED level requirement are non-conformant. Implementations that conform to all MUST and REQUIRED level requirements but fail to conform to SHOULD or RECOMMENDED level requirements are said to be "not fully conformant" but are still considered conformant.
+All normative text in this specification is contained in Sections 1–16. All appendices are informative except where explicitly marked normative. Examples throughout this document are informative unless explicitly stated otherwise.
 
 ### 1.2 Core Concepts
 
 - TOON document: A sequence of UTF-8 text lines formatted according to this spec.
-- Line: A sequence of non-newline characters terminated by LF (U+000A) in serialized form. Encoders MUST use LF.
+- Line: A sequence of non-newline characters. Serialized documents use LF (U+000A) as the line separator between lines; encoders MUST use LF, not CRLF.
 
 ### 1.3 Structural Terms
 
@@ -164,13 +146,13 @@ Implementations that fail to conform to any MUST or REQUIRED level requirement a
 
 - Header: The bracketed declaration for arrays, optionally followed by a field list, and terminating with a colon; e.g., key[3]: or items[2]{a,b}:.
 - Field list: Brace-enclosed, delimiter-separated list of field names for tabular arrays: {f1<delim>f2}.
-- List item: A line beginning with "- " at a given depth representing an element in an expanded array.
+- List item: A line beginning with "- " (or a bare "-" for an empty-object list item, §10) at a given depth representing an element in an expanded array.
 
 ### 1.5 Delimiter Terms
 
 - Delimiter: The character used to separate array/tabular values: comma (default), tab (HTAB, U+0009), or pipe ("|").
 - Document delimiter: The encoder-selected delimiter used for quoting decisions outside any array scope (default comma).
-- Active delimiter: The delimiter declared by the closest array header in scope, used to split inline primitive arrays and tabular rows under that header; it also governs quoting decisions for values within that array's scope.
+- Active delimiter: The delimiter declared by the closest array header in scope, used to split inline primitive arrays and tabular rows under that header. It governs quoting decisions for those inline values and row cells; object field values within the same scope use the document delimiter (see §11.1).
 
 ### 1.6 Type Terms
 
@@ -181,7 +163,7 @@ Implementations that fail to conform to any MUST or REQUIRED level requirement a
 
 ### 1.7 Conformance Terms
 
-- Strict mode: Decoder mode that enforces counts, indentation, and delimiter consistency; also rejects invalid escapes and missing colons (default: true).
+- Strict mode: Decoder mode that enforces counts, indentation, and delimiter consistency; also rejects invalid escapes and missing colons (default: true). See §14 for the authoritative list of strict-mode errors.
 
 ### 1.8 Notation
 
@@ -191,7 +173,7 @@ Implementations that fail to conform to any MUST or REQUIRED level requirement a
 ### 1.9 Key Folding and Path Expansion Terms
 
 - IdentifierSegment: A key segment eligible for safe folding and expansion, matching the pattern `^[A-Za-z_][A-Za-z0-9_]*$` (contains only letters, digits, and underscores; does not start with a digit; does not contain dots).
-- Path separator: The character used to join/split key segments during folding and expansion. Fixed to `"."` (U+002E, FULL STOP) in v1.5.
+- Path separator: The character used to join/split key segments during folding and expansion. Fixed to `"."` (U+002E, FULL STOP).
 - Note: Unquoted keys in TOON remain permissive per §7.3 (`^[A-Za-z_][A-Za-z0-9_.]*$`, allowing dots). IdentifierSegment is a stricter pattern used only for safe folding and expansion eligibility checks.
 
 ## 2. Data Model
@@ -204,63 +186,61 @@ Implementations that fail to conform to any MUST or REQUIRED level requirement a
   - Array order MUST be preserved.
   - Object key order MUST be preserved as encountered by the encoder.
 - Numbers (canonical form for encoding):
-  - Encoders MUST emit numbers in canonical decimal form:
+  - Encoders MUST emit finite numbers in canonical decimal form when n = 0, or when 1e-6 ≤ |n| < 1e21:
     - No exponent notation (e.g., 1e6 MUST be rendered as 1000000; 1e-6 as 0.000001).
     - No leading zeros except for the single digit "0" (e.g., "05" is not canonical).
     - No trailing zeros in the fractional part (e.g., 1.5000 MUST be rendered as 1.5).
     - If the fractional part is zero after normalization, emit as an integer (e.g., 1.0 → 1).
     - -0 MUST be normalized to 0.
-  - Encoders MUST emit sufficient precision to ensure round-trip fidelity within the encoder's host environment: decode(encode(x)) MUST equal x.
-  - If the encoder's host environment cannot represent a numeric value without loss (e.g., arbitrary-precision decimals or integers exceeding the host's numeric range), the encoder MAY:
-    - Emit a quoted string containing the exact decimal representation to preserve value fidelity, OR
-    - Emit a canonical number that round-trips to the host's numeric approximation (losing precision), provided it conforms to the canonical formatting rules above.
-  - Encoders SHOULD provide an option to choose lossless stringification for out-of-range numbers.
-- Numbers (decoding):
-  - Decoders MUST accept decimal and exponent forms on input (e.g., 42, -3.14, 1e-6, -1E+9).
-  - Decoders MUST treat tokens with forbidden leading zeros in the integer part (e.g., `"05"`, `"0001"`, `"-05"`, `"-0001"`) as strings, not numbers. This rule does **not** apply to a single zero integer part followed by a fractional or exponent part (e.g., `0.5`, `0e1`, `-0.5`, `-0e1`), which are valid numbers.
-  - If a decoded numeric token is not representable in the host's default numeric type without loss, implementations MAY:
-    - Return a higher-precision numeric type (e.g., arbitrary-precision integer or decimal), OR
-    - Return a string, OR
-    - Return an approximate numeric value if that is the documented policy.
-  - Implementations MUST document their policy for handling out-of-range or non-representable numbers. A lossless-first policy is RECOMMENDED for libraries intended for data interchange or validation.
-- Null: Represented as the literal null.
+  - For finite numbers outside the canonical range above (non-zero |n| < 1e-6, or |n| ≥ 1e21), encoders MAY emit exponent notation conforming to the JSON number grammar [RFC8259] §6 (e.g., 1e-7, 1e+21). Encoders SHOULD use lowercase `e` and an explicit exponent sign for byte-for-byte determinism.
+  - Encoders MUST emit sufficient precision so that, after any §3 host-type normalization, decode(encode(x)) equals x under JSON-model equality: null equals null; booleans compare by value; strings compare by Unicode scalar-value sequence after §7.1 unescaping, with no Unicode normalization; arrays compare by length and pairwise element equality in order; objects compare by the same ordered key sequence and pairwise value equality; numbers compare by mathematical value after §2 numeric normalization, so -0 equals 0 and integer-valued numbers compare equal to their integer form.
+  - If a source value is outside the implementation's documented numeric domain (e.g., arbitrary-precision decimals or integers exceeding that domain), the encoder MAY:
+    - Emit a quoted string containing a lossless decimal representation (plain decimal or JSON exponent form); the chosen form MUST be documented.
+    - Emit a number that round-trips to the host's numeric approximation (losing precision), provided it conforms to the rules above.
+  - Encoders SHOULD expose an option for lossless stringification of out-of-domain numbers.
+- Booleans: Encoders MUST emit the lowercase literals true and false.
+- Null: Encoders MUST emit the lowercase literal null.
+
+Decoder numeric rules are defined in §4.
 
 ## 3. Encoding Normalization (Reference Encoder)
 
 Encoders MUST normalize non-JSON values to the JSON data model before encoding. The mapping from host-specific types to JSON model is implementation-defined and MUST be documented.
 
 - Number:
-  - Finite → number (canonical decimal form per Section 2). -0 → 0.
+  - Finite → number per §2 number form rules.
   - NaN, +Infinity, -Infinity → null.
-- Implementations MAY honor host-language–specific serialization hooks (for example, a `toJSON()` method in JavaScript or an equivalent mechanism) as part of host-type normalization. When supported, such hooks SHOULD be applied before other host-type mappings and their behavior MUST be documented by the implementation.
+- Implementations MAY honor host-language–specific serialization hooks (for example, JavaScript's `toJSON()`, Go's `json.Marshaler`, Python's `JSONEncoder.default`, Rust's `serde::Serialize`, or an equivalent mechanism) as part of host-type normalization. When supported, such hooks SHOULD take precedence over default host-type mappings for the same value, and their behavior MUST be documented by the implementation.
 - Examples of host-type normalization (non-normative):
-  - Date/time objects → ISO 8601 string representation.
+  - Date/time objects → ISO 8601 string representation [ISO8601].
   - Set-like collections → array.
   - Map-like collections → object (with string keys).
-  - Undefined, function, symbol, or unrecognized types → null.
+  - Sentinel, non-serializable, or unrecognized host values → null.
 
-See Appendix G for non-normative language-specific examples (Go, JavaScript, Python, Rust).
+See Appendix F for non-normative language-specific examples.
 
 ## 4. Decoding Interpretation (Reference Decoder)
 
 Decoders map text tokens to host values:
 
 - Quoted tokens (strings and keys):
-  - MUST be unescaped per Section 7.1 (only \\, \", \n, \r, \t are valid). Any other escape or an unterminated string MUST error.
+  - MUST be unescaped per §7.1. Any other escape or an unterminated string MUST error.
   - Quoted primitives remain strings even if they look like numbers/booleans/null.
 - Unquoted value tokens:
   - true, false, null → booleans/null.
   - Numeric parsing:
-    - MUST accept standard decimal and exponent forms (e.g., 42, -3.14, 1e-6, -1E+9).
-    - MUST treat tokens with forbidden leading zeros (e.g., "05", "0001") as strings (not numbers).
+    - Decoders MUST accept decimal and exponent forms on input (e.g., `42`, `-3.14`, `1e-6`, `-1E+9`).
+    - Decoders MUST treat tokens with forbidden leading zeros in the integer part (e.g., `"05"`, `"0001"`, `"-05"`, `"-0001"`) as strings, not numbers. This rule does **not** apply to a single zero integer part followed by a fractional or exponent part (e.g., `0.5`, `0e1`, `-0.5`, `-0e1`), which are valid numbers.
     - Only finite numbers are expected from conforming encoders.
+    - If a decoded numeric token is not representable within the implementation's documented numeric domain, implementations MAY return a higher-precision numeric type, return a string, or return an approximate numeric value if that is the documented policy. Implementations MUST document their out-of-range policy; lossless-first is RECOMMENDED for libraries intended for data interchange or validation.
     - Decoding examples:
-      - `"1.5000"` → numeric value `1.5` (trailing zeros in fractional part are accepted)
-      - `"-1E+03"` → numeric value `-1000` (exponent forms are accepted)
-      - `"-0"` → numeric value `0` (negative zero decodes to zero; most host environments do not distinguish -0 from 0)
+      - `1.5000` → `1.5` (trailing zeros in fractional part accepted)
+      - `-1E+03` → `-1000` (exponent forms accepted)
+      - `-0` → `0` (negative zero decodes to zero; most host environments do not distinguish -0 from 0)
+  - The literal token `[]` in object field position (`key: []`) and root position (`[]`) decodes as an empty array (§9.1).
   - Otherwise → string.
 - Keys:
-  - Decoded as strings (quoted keys MUST be unescaped per Section 7.1).
+  - Decoded as strings (quoted keys MUST be unescaped per §7.1).
   - A colon MUST follow a key; missing colon MUST error.
 
 ## 5. Concrete Syntax and Root Form
@@ -269,15 +249,16 @@ TOON is a deterministic, line-oriented, indentation-based notation.
 
 - Objects:
   - key: value for primitives.
-  - key: alone for nested or empty objects; nested fields appear at depth +1.
+  - key: alone for nested or empty objects (see §8).
 - Arrays:
   - Primitive arrays are inline: key[N<delim?>]: v1<delim>v2….
   - Arrays of arrays (primitives): expanded list items under a header: key[N<delim?>]: then "- [M<delim?>]: …".
   - Arrays of objects:
     - Tabular form when uniform and primitive-only: key[N<delim?>]{f1<delim>f2}: then one row per line.
-    - Otherwise: expanded list items: key[N<delim?>]: with "- …" items (see Sections 9.4 and 10).
+    - Otherwise: expanded list items: key[N<delim?>]: with "- …" items (see §9.4 and §10).
 - Root form discovery:
-  - If the first non-empty depth-0 line is a valid root array header per Section 6 (must include a colon), decode a root array.
+  - If the first non-empty depth-0 line is a valid root array header per §6, decode a root array.
+  - Else if the document has exactly one non-empty line and it is the literal token `[]`, decode an empty root array (§9.1).
   - Else if the document has exactly one non-empty line and it is neither a valid array header nor a key-value line (quoted or unquoted key), decode a single primitive (examples: `hello`, `42`, `true`).
   - Otherwise, decode an object.
   - An empty document (no non-empty lines after ignoring trailing newline(s) and ignorable blank lines) decodes to an empty object `{}`.
@@ -303,31 +284,25 @@ Where:
   - absent for comma (","),
   - HTAB (U+0009) for tab,
   - "|" for pipe.
-- Field names in braces are separated by the same active delimiter and encoded as keys (Section 7.3).
+- Field names in braces are separated by the same active delimiter and encoded as keys (§7.3).
 
 Spacing and delimiters:
-- Every header line MUST end with a colon.
-- When inline values follow a header on the same line (non-empty primitive arrays), there MUST be exactly one space after the colon before the first value.
+- Every header MUST include a colon after the bracket segment and optional fields segment.
+- Encoder whitespace after the colon and decoder tolerance are governed by §12.
 - The active delimiter declared by the bracket segment applies to:
   - splitting inline primitive arrays on that header line,
   - splitting tabular field names in "{…}",
   - splitting all rows/items within the header's scope,
   - unless a nested header changes it.
-- The same delimiter symbol declared in the bracket MUST be used in the fields segment and in all row/value splits in that scope.
+- Decoders MUST split the fields segment and all rows/items in the header's scope using the declared delimiter; other delimiter characters appearing unquoted in row content are literal data and MUST NOT be re-interpreted as structural delimiters.
 - Absence of a delimiter symbol in a bracket segment ALWAYS means comma, regardless of any parent header.
 
 Normative header grammar (ABNF):
 ```
-; Core rules from RFC 5234
-ALPHA  = %x41-5A / %x61-7A   ; A-Z / a-z
-DIGIT  = %x30-39             ; 0-9
-DQUOTE = %x22                ; "
-HTAB   = %x09                ; horizontal tab
-LF     = %x0A                ; line feed
-SP     = %x20                ; space
+; Core rules per RFC 5234 §B.1 (ALPHA, DIGIT, DQUOTE, HTAB)
 
-; Header syntax
-bracket-seg   = "[" 1*DIGIT [ delimsym ] "]"
+bracket-seg   = "[" length [ delimsym ] "]"
+length        = "0" / ( %x31-39 *DIGIT )   ; non-negative integer, no leading zeros
 delimsym      = HTAB / "|"
 ; Field names are keys (quoted/unquoted) separated by the active delimiter
 fields-seg    = "{" fieldname *( delim fieldname ) "}"
@@ -336,56 +311,67 @@ fieldname     = key
 
 header        = [ key ] bracket-seg [ fields-seg ] ":"
 key           = unquoted-key / quoted-key
-
-; Unquoted keys must match identifier pattern
 unquoted-key  = ( ALPHA / "_" ) *( ALPHA / DIGIT / "_" / "." )
-
-; Quoted keys use only escapes from Section 7.1
-; (Exact escaped-char repertoire is defined in Section 7.1)
-; quoted-key   = DQUOTE *(escaped-char / safe-char) DQUOTE
+quoted-key    = DQUOTE *quoted-char DQUOTE
+; quoted-char is defined in §7.1
 ```
 
-Note: The ABNF grammar above cannot enforce that the delimiter used in the fields segment (braces) matches the delimiter declared in the bracket segment. This equality requirement is normative per the prose in lines 311-312 above and MUST be enforced by implementations. Mismatched delimiters between bracket and brace segments MUST error in strict mode.
+Note: The ABNF does not express delimiter equality between the bracket and fields segments; implementations enforce the same-delimiter rule above. Mismatched delimiters MUST error in strict mode.
 
-Note: The grammar above specifies header syntax. TOON's grammar is deliberately designed to prioritize human readability and token efficiency over strict LR(1) parseability. This requires some context-sensitive parsing (particularly for tabular row disambiguation in Section 9.3), which is a deliberate design tradeoff. Reference implementations demonstrate that deterministic parsing is achievable with modest lookahead.
+Note: The grammar above specifies header syntax only. Tabular row disambiguation is defined in §9.3.
 
-Between the closing bracket `]` of the bracket segment and the opening brace `{` of a fields segment (or the colon `:` if no fields segment is present), only whitespace MAY appear. If a decoder encounters non-whitespace content in these positions (e.g., additional bracket expressions like `[bar]`), the line MUST NOT be interpreted as an array header. Decoders SHOULD fall through to key-value parsing (Section 8), treating the entire pre-colon content as a literal key.
+Content MUST NOT appear between `]` and `{`/`:`. Invalid bracket lengths (e.g., `[bar]`, `[03]`, `[-1]`) or intervening content (e.g., `[1][bar]:`, `[2]extra:`, `[2] :`) are strict-mode errors; non-strict decoders MAY parse the line as a key-value line, with the key treated as a literal token (not constrained by §7.3's unquoted-key regex).
 
 Decoding requirements:
-- The bracket segment MUST parse as a non-negative integer length N.
+- The bracket segment MUST parse as a non-negative integer length N with no leading zeros (the single digit `0` is the only canonical form for length zero). Tokens like `[03]` or `[-1]` MUST NOT be interpreted as bracket segments.
 - If a trailing tab or pipe appears inside the brackets, it selects the active delimiter; otherwise comma is active.
-- If a fields segment occurs between the bracket and the colon, parse field names using the active delimiter; quoted names MUST be unescaped per Section 7.1.
+- If a fields segment occurs between the bracket and the colon, parse field names using the active delimiter; quoted names MUST be unescaped per §7.1.
 - A colon MUST follow the bracket and optional fields; missing colon MUST error.
 
 Note: Key folding (§13.4) affects only the key prefix in headers. The header grammar remains unchanged. Example: `data.meta.items[2]{id,name}:` is a valid header with a folded key prefix `data.meta.items`, followed by a standard bracket segment, field list, and colon. Parsing treats folded keys as literal keys; see §13.4 for optional path expansion.
 
 ## 7. Strings and Keys
 
-### 7.1 Escaping (Encoding and Decoding)
+### 7.1 Escaping
 
-In quoted strings and keys, the following characters MUST be escaped:
-- "\\" → "\\\\"
-- "\"" → "\\\""
-- U+000A newline → "\\n"
-- U+000D carriage return → "\\r"
-- U+0009 tab → "\\t"
+In quoted strings and keys, codepoints are encoded according to the following table; rows are matched top-to-bottom, and the first matching row applies. Encoders MUST follow the **Encoder** column; decoders MUST follow the **Decoder** column.
 
-Decoders MUST reject any other escape sequence and unterminated strings.
+| Codepoint set                                          | Encoder                                       | Decoder                                                         |
+|--------------------------------------------------------|-----------------------------------------------|-----------------------------------------------------------------|
+| `\` (U+005C)                                           | MUST emit `\\`                                | MUST decode `\\` → `\`                                          |
+| `"` (U+0022)                                           | MUST emit `\"`                                | MUST decode `\"` → `"`                                          |
+| LF (U+000A)                                            | MUST emit `\n`                                | MUST decode `\n` → LF                                           |
+| CR (U+000D)                                            | MUST emit `\r`                                | MUST decode `\r` → CR                                           |
+| HTAB (U+0009)                                          | MUST emit `\t`                                | MUST decode `\t` → HTAB                                         |
+| Other U+0000–U+001F controls                           | MUST emit `\uXXXX` (lowercase hex SHOULD)     | MUST decode `\uXXXX` (case-insensitive hex)                     |
+| U+D800–U+DFFF lone surrogates                          | (not produced by valid encoders)              | MUST reject when decoded from `\uXXXX`                          |
+| Other BMP codepoints (U+0020–U+D7FF, U+E000–U+FFFF)    | SHOULD emit literal UTF-8; MAY emit `\uXXXX`  | MUST accept either form                                         |
+| Supplementary scalar values (U+10000–U+10FFFF)         | MUST emit as literal UTF-8                    | MUST accept literal UTF-8; surrogate `\uXXXX` escapes MUST be rejected (see row above) |
 
-Tabs are allowed inside quoted strings and as a declared delimiter; they MUST NOT be used for indentation (Section 12).
+Decoders MUST reject any escape sequence not listed above, MUST reject `\u` followed by fewer than four hex digits, and MUST reject unterminated strings.
 
-### 7.2 Quoting Rules for String Values (Encoding)
+Normative escape grammar:
+
+```abnf
+HEXDIG         = DIGIT / %x41-46 / %x61-66
+quoted-char    = escaped-char / unescaped-char
+unescaped-char = %x09 / %x20-21 / %x23-5B / %x5D-D7FF / %xE000-FFFF / %x10000-10FFFF
+escaped-char   = %x5C ( %x5C / DQUOTE / %x6E / %x72 / %x74 / unicode-escape )
+unicode-escape = %x75 4HEXDIG
+```
+
+Tabs are allowed inside quoted strings and as a declared delimiter; they MUST NOT be used for indentation (§12). Within quoted strings, encoders MUST emit HTAB as `\t` per the escape table above; the literal HTAB in `unescaped-char` expresses decoder leniency only.
+
+### 7.2 Quoting Rules for String Values
 
 A string value MUST be quoted if any of the following is true:
 - It is empty ("").
 - It has leading or trailing whitespace.
 - It equals true, false, or null (case-sensitive).
-- It is numeric-like:
-  - Matches /^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i (e.g., "42", "-3.14", "1e-6").
-  - Or matches /^0\d+$/ (leading-zero decimals such as "05").
-- It contains a colon (:), double quote ("), or backslash (\).
+- It is numeric-like: matches /^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i (e.g., "42", "-3.14", "05", "1e-6").
+- It contains a colon (:), double quote ("), or backslash (\\).
 - It contains brackets or braces ([, ], {, }).
-- It contains control characters: newline, carriage return, or tab.
+- It contains control characters in U+0000 through U+001F.
 - It contains the relevant delimiter (see §11 for complete delimiter rules):
   - For inline array values and tabular row cells: the active delimiter from the nearest array header.
   - For object field values (key: value): the document delimiter, even when the object is within an array's scope.
@@ -393,21 +379,21 @@ A string value MUST be quoted if any of the following is true:
 
 Otherwise, the string MAY be emitted without quotes. Unicode, emoji, and strings with internal (non-leading/trailing) spaces are safe unquoted provided they do not violate the conditions.
 
-### 7.3 Key Encoding (Encoding)
+### 7.3 Key Encoding
 
 Object keys and tabular field names:
 - MAY be unquoted only if they match: ^[A-Za-z_][A-Za-z0-9_.]*$.
-- Otherwise, they MUST be quoted and escaped per Section 7.1.
+- Otherwise, they MUST be quoted and escaped per §7.1.
 
 Keys requiring quoting per the above rules MUST be quoted in all contexts, including array headers (e.g., "my-key"[N]:).
 
 Encoders MAY perform key folding when enabled (see §13.4 for complete folding rules and requirements).
 
-### 7.4 Decoding Rules for Strings and Keys (Decoding)
+### 7.4 Decoding Rules for Strings and Keys
 
 Decoding of value tokens follows §4 (unquoted type inference, quoted strings, numeric rules). This section adds key-specific requirements:
 
-- Quoted keys MUST be unescaped per Section 7.1; any other escape MUST error.
+- Quoted keys MUST be unescaped per §7.1; any other escape MUST error.
 - Keys (quoted or unquoted) MUST be followed by ":"; missing colon MUST error (see also §14.2).
 
 ## 8. Objects
@@ -420,45 +406,51 @@ Decoding of value tokens follows §4 (unquoted type inference, quoted strings, n
 - Dotted keys (e.g., `user.name`) are valid literal keys in TOON. Decoders MUST treat them as single literal keys unless path expansion is explicitly enabled (see §13.4). This preserves backward compatibility and allows safe opt-in expansion behavior.
 - Decoding:
   - A line "key:" with nothing after the colon at depth d opens an object; subsequent lines at depth > d belong to that object until the depth decreases to ≤ d.
+  - A bare `key:` (no value after the colon) MUST decode as an empty or nested object, NOT an empty array. Empty arrays use the explicit `key: []` form (§9.1).
   - Lines "key: value" at the same depth are sibling fields.
+  - Duplicate sibling keys at the same depth: see §14.4 for strict/non-strict behavior.
 
 ## 9. Arrays
 
 ### 9.1 Primitive Arrays (Inline)
 
 - Encoding:
-  - Non-empty arrays: key[N<delim?>]: v1<delim>v2<delim>… where each vi is encoded as a primitive (Section 7) with delimiter-aware quoting.
-  - Empty arrays: key[0<delim?>]: (no values following).
-  - Root arrays: [N<delim?>]: v1<delim>…
+  - Non-empty arrays: `key[N<delim?>]: v1<delim>v2<delim>…` where each vi is encoded as a primitive (§7) with delimiter-aware quoting.
+  - Empty arrays (object field position): encoders SHOULD emit `key: []`. Encoders MAY emit the legacy header form `key[0<delim?>]:` for backward compatibility.
+  - Empty arrays (root position): encoders SHOULD emit `[]` on its own line. Encoders MAY emit the legacy `[0<delim?>]:` form.
+  - Root arrays: `[N<delim?>]: v1<delim>…`
 - Decoding:
-  - Split using the active delimiter declared by the header; non-active delimiters MUST NOT split values.
+  - Split using the active delimiter declared by the header (§11.2).
   - When splitting inline arrays, empty tokens (including those surrounded by whitespace) decode to the empty string.
   - In strict mode, the number of decoded values MUST equal N; otherwise MUST error.
+  - Empty arrays: decoders MUST accept `key: []`, `[]`, and the legacy forms `key[0<delim?>]:` and `[0<delim?>]:` as empty arrays.
 
-### 9.2 Arrays of Arrays (Primitives Only) — Expanded List
+### 9.2 Arrays of Arrays (Primitives Only) – Expanded List
 
 - Encoding:
-  - Parent header: key[N<delim?>]: on its own line.
+  - Parent header: `key[N<delim?>]:` on its own line.
   - Each inner primitive array is a list item:
-    - - [M<delim?>]: v1<delim>v2<delim>…
-    - Empty inner arrays: - [0<delim?>]:
+    - `- [M<delim?>]: v1<delim>v2<delim>…`
+    - Empty inner arrays: `- [0<delim?>]:`
+    - The `key: []` field-level form (§9.1) does NOT apply to list-item inner arrays.
 - Decoding:
-  - Items appear at depth +1, each starting with "- " and an inner array header "[M<delim?>]: …".
+  - Items appear at depth +1, each starting with "- " and an inner array header `[M<delim?>]: …`.
   - Inner arrays are split using their own active delimiter; in strict mode, counts MUST match M.
   - In strict mode, the number of list items MUST equal outer N.
 
-### 9.3 Arrays of Objects — Tabular Form
+### 9.3 Arrays of Objects – Tabular Form
 
 Tabular detection (encoding; MUST hold for all elements):
 - Every element is an object.
+- Each object has at least one key; arrays containing any empty object `{}` MUST NOT use tabular form (encode via §9.4 instead).
 - All objects have the same set of keys (order per object MAY vary).
 - All values across these keys are primitives (no nested arrays/objects).
 
 When satisfied (encoding):
-- Header: key[N<delim?>]{f1<delim>f2<delim>…}: where field order is the first object's key encounter order.
-- Field names encoded per Section 7.3.
-- Rows: one line per object at depth +1 under the header; values are encoded primitives (Section 7) and joined by the active delimiter.
-- Root tabular arrays omit the key: [N<delim?>]{…}: followed by rows.
+- Header: `key[N<delim?>]{f1<delim>f2<delim>…}:` where field order is the first object's key encounter order.
+- Field names encoded per §7.3.
+- Rows: one line per object at depth +1 under the header; values are encoded primitives (§7) and joined by the active delimiter.
+- Root tabular arrays omit the key: `[N<delim?>]{…}:` followed by rows.
 
 Decoding:
 - A tabular header declares the active delimiter and ordered field list.
@@ -473,24 +465,24 @@ Decoding:
     - Delimiter before colon → row.
     - Colon before delimiter → key-value line (end of rows).
   - If a line has an unquoted colon but no unquoted active delimiter → key-value line (end of rows).
-- When a tabular array appears as the first field of a list-item object, indentation is governed by Section 10.
+- When a tabular array appears as the first field of a list-item object, indentation is governed by §10.
 
-### 9.4 Mixed / Non-Uniform Arrays — Expanded List
+### 9.4 Mixed / Non-Uniform Arrays – Expanded List
 
 When tabular requirements are not met (encoding):
-- Header: key[N<delim?>]:
+- Header: `key[N<delim?>]:`
 - Each element is rendered as a list item at depth +1 under the header:
-  - Primitive: - <primitive>
-  - Primitive array: - [M<delim?>]: v1<delim>…
-  - Object: formatted per Section 10 (objects as list items).
-  - Complex arrays: - key'[M<delim?>]: followed by nested items as appropriate.
+  - Primitive: `- <primitive>`
+  - Primitive array: `- [M<delim?>]: v1<delim>…`
+  - Array of objects or non-uniform array: `- [M<delim?>]:` on the hyphen line, followed by the nested array's list items at depth +1 relative to the hyphen line (i.e. +2 from the outer array header). Items are encoded recursively per §9.1–§9.4 as each item's shape requires; tabular form (§9.3) is not available in this position (the field list has no place to appear) – encoders MUST use the expanded list form.
+  - Object: formatted per §10 (objects as list items).
 
 Decoding:
 - Header declares list length N and the active delimiter for any nested inline arrays.
-- Each list item starts with "- " at depth +1 and is parsed as:
+- Each list item starts with "- " at depth +1 (or the bare marker "-" for an empty object list item, §10) and is parsed as:
   - Primitive (no colon and no array header),
-  - Inline primitive array (- [M<delim?>]: …),
-  - Object with first field on the hyphen line (- key: … or - key[N…]{…}: …),
+  - Inline primitive array (`- [M<delim?>]: …`),
+  - Object with first field on the hyphen line (`- key: …` or `- key[N…]{…}: …`),
   - Or nested arrays via nested headers.
 - In strict mode, the number of list items MUST equal N.
 
@@ -500,26 +492,26 @@ For an object appearing as a list item:
 
 - Empty object list item: a single "-" at the list-item indentation level.
 - Encoding (normative):
-  - When a list-item object has a tabular array (Section 9.3) as its first field in encounter order, encoders MUST emit the tabular header on the hyphen line:
-    - The hyphen and tabular header appear on the same line at the list-item depth: - key[N<delim?>]{fields}:
+  - When a list-item object has a tabular array (§9.3) as its first field in encounter order, encoders MUST emit the tabular header on the hyphen line:
+    - The hyphen and tabular header appear on the same line at the list-item depth: `- key[N<delim?>]{fields}:`
     - Tabular rows MUST appear at depth +2 (relative to the hyphen line).
-    - All other fields of the same object MUST appear at depth +1 under the hyphen line, in encounter order, using normal object field rules (Section 8).
+    - All other fields of the same object MUST appear at depth +1 under the hyphen line, in encounter order, using normal object field rules (§8).
     - Encoders MUST NOT emit tabular rows at depth +1 or sibling fields at the same depth as rows when the first field is a tabular array.
   - For all other cases (first field is not a tabular array), encoders SHOULD place the first field on the hyphen line. A bare hyphen on its own line is used only for empty list-item objects.
 - Decoding (normative):
-  - When a decoder encounters a list-item line of the form - key[N<delim?>]{fields}: at depth d, it MUST treat this as the start of a tabular array field named key in the list-item object.
-  - Lines at depth d+2 that conform to tabular row syntax (Section 9.3) are rows of that tabular array.
+  - When a decoder encounters a list-item line of the form `- key[N<delim?>]{fields}:` at depth d, it MUST treat this as the start of a tabular array field named key in the list-item object.
+  - Lines at depth d+2 that conform to tabular row syntax (§9.3) are rows of that tabular array.
   - Lines at depth d+1 are additional fields of the same list-item object; the presence of a line at depth d+1 after rows terminates the rows.
-  - All other object-as-list-item patterns (bare hyphen, first field on hyphen line for non-tabular values) are decoded according to the general rules in Section 8 and Section 9.
+  - All other object-as-list-item patterns (bare hyphen, first field on hyphen line for non-tabular values) are decoded according to the general rules in §8 and §9.
 
 ## 11. Delimiters
 
 - Supported delimiters:
   - Comma (default): header omits the delimiter symbol.
-  - Tab: header includes HTAB inside brackets and braces (e.g., [N<TAB>], {a<TAB>b}); rows/inline arrays use tabs.
+  - Tab: header includes HTAB inside brackets and braces (e.g., `[N<TAB>]`, `{a<TAB>b}`); rows/inline arrays use tabs.
   - Pipe: header includes "|" inside brackets and braces; rows/inline arrays use "|".
 
-### 11.1 Encoding Rules (Normative for Encoders)
+### 11.1 Encoding Rules
 
 - Document delimiter: Encoders select a document delimiter (option: comma, tab, pipe; default comma) that influences quoting for all object field values (key: value) throughout the document.
 - Active delimiter: Inside an array header's scope, the active delimiter governs quoting only for inline array values and tabular row cells.
@@ -528,14 +520,12 @@ For an object appearing as a list item:
   - Object field values (key: value): encoders use the document delimiter to decide delimiter-aware quoting, regardless of whether the object appears within an array's scope.
   - Strings containing non-active delimiters do not require quoting unless another condition applies (§7.2).
 
-### 11.2 Decoding Rules (Normative for Decoders)
+### 11.2 Decoding Rules
 
-- Active delimiter: Decoders use only the active delimiter declared by the nearest array header to split inline arrays and tabular rows.
 - Delimiter-aware parsing:
-  - Inline arrays and tabular rows MUST be split only on the active delimiter.
+  - Inline arrays and tabular rows MUST be split only on the active delimiter declared by the nearest array header.
   - Splitting MUST preserve empty tokens; surrounding spaces are trimmed, and empty tokens decode to the empty string.
   - Nested headers may change the active delimiter; decoding MUST use the delimiter declared by the nearest header.
-  - If the bracket declares tab or pipe, the same symbol MUST be used in the fields segment and for splitting all rows/values in that scope (§6).
 - Object field values (key: value): Decoders parse the entire post-colon token as a single value; document delimiter is not a decoder concept.
 
 ## 12. Indentation and Whitespace
@@ -543,65 +533,82 @@ For an object appearing as a list item:
 - Encoding:
   - Encoders MUST use a consistent number of spaces per level (default 2; configurable).
   - Tabs MUST NOT be used for indentation.
-  - Exactly one space after ": " in key: value lines.
-  - Exactly one space after array headers when followed by inline values.
-  - No trailing spaces at the end of any line.
-  - No trailing newline at the end of the document.
+  - Encoders MUST emit exactly one ASCII space (U+0020) after the colon in key: value lines.
+  - Encoders MUST emit exactly one ASCII space (U+0020) after array headers when followed by inline values.
+  - Encoders MUST NOT emit trailing spaces at the end of any line.
+  - Encoders MUST NOT emit a trailing newline at the end of the document.
 - Decoding:
   - Strict mode:
     - The number of leading spaces on a line MUST be an exact multiple of indentSize; otherwise MUST error.
-    - Tabs used as indentation MUST error. Tabs are allowed in quoted strings and as the HTAB delimiter.
+    - Tabs used as indentation MUST error (see §7.1 for tabs in quoted strings and as the HTAB delimiter).
   - Non-strict mode:
     - Depth MAY be computed as floor(indentSpaces / indentSize).
     - Implementations MAY accept tab characters in indentation. Depth computation for tabs is implementation-defined. Implementations MUST document their tab policy.
   - Surrounding whitespace around tokens SHOULD be tolerated; internal semantics follow quoting rules.
   - Blank lines:
+    - A line whose content trims to empty MAY be treated as blank regardless of leading-space count.
     - Outside arrays/tabular rows: decoders SHOULD ignore completely blank lines (do not create/close structures).
     - Inside arrays/tabular rows: in strict mode, MUST error; in non-strict mode, MAY be ignored and not counted as a row/item.
   - Trailing newline at end-of-file: decoders SHOULD accept; validators MAY warn.
 
-Recommended blank-line handling (normative where stated):
-- Before decoding, or during scanning:
-  - Track blank lines with depth.
-  - For strict mode: if a blank line occurs between the first and last row/item line in an array/tabular block, this MUST error.
-  - Otherwise (outside arrays/tabular rows), blank lines SHOULD be skipped and not contribute to root-form detection.
-- Empty input means: after ignoring trailing newlines and ignorable blank lines outside arrays/tabular rows, there are no non-empty lines.
-
 ## 13. Conformance and Options
 
-Conformance classes:
+Encoders, decoders, and validators each have a per-class checklist below (§13.1–§13.3). Conforming implementations MUST satisfy every applicable item.
 
-- Encoder:
-  - MUST produce output adhering to all normative rules in Sections 2–12 and 15.
-  - MUST be deterministic regarding:
-    - Object field order (encounter order).
-    - Tabular detection (uniform vs non-uniform).
-    - Quoting decisions given values and delimiter context (document delimiter or active delimiter in array scope).
-
-- Decoder:
-  - MUST implement tokenization, escaping, and type interpretation per Sections 4 and 7.4.
-  - MUST parse array headers per Section 6 and apply the declared active delimiter to inline arrays and tabular rows.
-  - MUST implement structure and depth rules per Sections 8–11, including objects-as-list-items placement.
-  - MUST enforce strict-mode rules in Section 14 when strict = true.
-
-- Validator:
-  - SHOULD verify structural conformance (headers, indentation, list markers).
-  - SHOULD verify whitespace invariants.
-  - SHOULD verify delimiter consistency between headers and rows.
-  - SHOULD verify length counts vs declared [N].
+Option names throughout this specification are concept handles; implementations MAY use language-idiomatic spellings (e.g., `key_folding` in Python, `KeyFolding` in Go) when the mapping is documented. Option value tokens (e.g., `"off"`, `"safe"`) likewise denote modes; implementations MAY use enums, constants, or other host-idiomatic types.
 
 Options:
 - Encoder options:
-  - indent (default: 2 spaces)
+  - indentSize (default: 2 spaces)
   - delimiter (document delimiter; default: comma; alternatives: tab, pipe)
   - keyFolding (default: `"off"`; alternatives: `"safe"`)
-  - flattenDepth (default: Infinity when keyFolding is `"safe"`; non-negative integer ≥ 0; values 0 or 1 have no practical folding effect)
+  - flattenDepth (default: Infinity when keyFolding is `"safe"`; non-negative integer; values less than 2 have no practical effect)
 - Decoder options:
-  - indent (default: 2 spaces)
+  - indentSize (default: 2 spaces)
   - strict (default: `true`)
   - expandPaths (default: `"off"`; alternatives: `"safe"`)
 
 Strict-mode errors are enumerated in §14; validators MAY add informative diagnostics for style and encoding invariants.
+
+### 13.1 Encoder Conformance Checklist
+
+Conforming encoders MUST:
+- [ ] Produce UTF-8 output with LF (U+000A) line endings (§1.2)
+- [ ] Use consistent indentation (default 2 spaces, no tabs) (§12)
+- [ ] Escape per §7.1 in quoted strings; never emit other escapes
+- [ ] Quote strings per §7.2 (the relevant delimiter is governed by §11.1: document delimiter for object-field values, active delimiter for inline array values and tabular row cells)
+- [ ] Emit array lengths [N] matching actual item count (§6, §9)
+- [ ] Preserve object key order as encountered (§2)
+- [ ] Emit numbers per §2
+- [ ] Convert -0 to 0 (§2)
+- [ ] Emit booleans and null as lowercase literals (§2)
+- [ ] Convert NaN/±Infinity to null (§3)
+- [ ] Emit no trailing spaces or trailing newline (§12)
+- [ ] When `keyFolding="safe"`, folding MUST comply with §13.4 (IdentifierSegment validation, collision avoidance)
+- [ ] When `flattenDepth` is set, folding MUST stop at the configured segment count (§13.4)
+
+### 13.2 Decoder Conformance Checklist
+
+Conforming decoders MUST:
+- [ ] Parse array headers per §6 (length, delimiter, optional fields)
+- [ ] Accept empty arrays in both forms: `key: []` / `[]` and legacy `key[0]:` / `[0]:` (§9.1)
+- [ ] Split inline arrays and tabular rows using active delimiter only (§11)
+- [ ] Unescape per §7.1
+- [ ] Type unquoted primitives: true/false/null → booleans/null, numeric → number, else → string (§4)
+- [ ] Enforce strict-mode rules when `strict=true` (§14)
+- [ ] Preserve array order and object key order (§2)
+- [ ] When `expandPaths="safe"`, expansion MUST follow §13.4 (IdentifierSegment-only segments, deep merge, conflict rules)
+- [ ] When `expandPaths="safe"` with `strict=true`, MUST error on expansion conflicts per §14.3
+- [ ] When `expandPaths="safe"` with `strict=false`, apply LWW conflict resolution (§13.4)
+
+### 13.3 Validator Conformance Checklist
+
+Validators SHOULD verify:
+- [ ] Structural conformance (headers, indentation, list markers)
+- [ ] Whitespace invariants (no trailing spaces/newlines)
+- [ ] Delimiter consistency between headers and rows
+- [ ] Array length counts match declared [N]
+- [ ] All strict-mode requirements (§14)
 
 ### 13.4 Key Folding and Path Expansion
 
@@ -615,32 +622,30 @@ Mode: `"off"` | `"safe"` (default: `"off"`)
 - `"off"`: No folding is performed. All objects are encoded with standard nesting.
 - `"safe"`: Fold eligible chains according to the rules below.
 
-flattenDepth: The maximum number of segments from K0 to include in the folded path (default: Infinity when keyFolding is `"safe"`; values less than 2 have no practical effect).
-- A value of 2 folds only two-segment chains: `{a: {b: val}}` → `a.b: val`.
+flattenDepth: The maximum number of segments from K1 to include in the folded path (default: Infinity when keyFolding is `"safe"`; values less than 2 have no practical effect).
+- A value of 2 folds the first two segments of an eligible chain: `{a: {b: val}}` → `a.b: val`; longer chains continue nested below the folded key.
 - A value of Infinity folds entire eligible chains: `{a: {b: {c: val}}}` → `a.b.c: val`.
 
-Foldable chain: A chain K0 → K1 → ... → Kn is foldable when:
-- Each Ki (where i = 0 to n−1) is an object with exactly one key Ki+1.
+Foldable chain: A chain of L segments K1 → K2 → ... → KL is foldable when:
+- Each Ki (where 1 ≤ i < L) is an object with exactly one key Ki+1.
 - The chain stops at the first non-single-key object or when encountering a leaf value.
 - Arrays are not considered single-key objects; a chain stops at arrays.
-- The leaf value at Kn is either a primitive, an array, or an empty object.
+- The leaf value at KL is either a primitive, an array, or an empty object.
 
 Safe mode requirements (all MUST hold for a chain to be folded):
-1. All folded segments K0 through K(d−1) (where d = min(chain length, flattenDepth)) MUST be IdentifierSegments (§1.9): matching `^[A-Za-z_][A-Za-z0-9_]*$`.
-2. No segment may contain the path separator (`.` in v1.5).
-3. The resulting folded key string MUST NOT equal any existing sibling literal key at the same object depth (collision avoidance).
-4. If any segment would require quoting per §7.3, the chain MUST NOT be folded.
+1. All folded segments K1 through Kd (where d = min(L, flattenDepth)) MUST be IdentifierSegments (§1.9): matching `^[A-Za-z_][A-Za-z0-9_]*$`.
+2. The resulting folded key string MUST NOT equal any existing sibling literal key at the same object depth (collision avoidance).
 
 Folding process:
-- For a foldable chain of length n, determine d = min(n, flattenDepth).
-- Fold segments K0 through K(d−1) into a single key: `K0.K1.....K(d−1)`.
-- If d < n, emit the remaining structure (Kd through Kn) as normal nested objects.
-- The leaf value at Kn is encoded normally (primitive, array, or empty object).
+- For a foldable chain of L segments, determine d = min(L, flattenDepth).
+- Fold segments K1 through Kd into a single key: `K1.K2.....Kd`.
+- If d < L, emit the remaining structure (Kd+1 through KL) as normal nested objects.
+- The leaf value at KL is encoded normally (primitive, array, or empty object).
 
 Examples:
 - `{a: {b: {c: 1}}}` with safe mode, depth=Infinity → `a.b.c: 1`
 - `{a: {b: {c: {d: 1}}}}` with safe mode, depth=2 → produces `a.b:` followed by nested `c:` and `d: 1` at appropriate depths
-- `{data: {"full-name": {x: 1}}}` → safe mode skips (segment `"full-name"` requires quoting); emits standard nested structure
+- `{data: {"full-name": {x: 1}}}` → safe mode skips (segment `"full-name"` is not an IdentifierSegment); emits standard nested structure
 
 #### Decoder: Path Expansion
 
@@ -651,9 +656,9 @@ Mode: `"off"` | `"safe"` (default: `"off"`)
 - `"safe"`: Expand eligible dotted keys according to the rules below.
 
 Safe mode behavior:
-- Any key containing the path separator (`.`) is considered for expansion.
+- Any unquoted key containing the path separator (`.`) is considered for expansion; quoted keys remain literal after unescaping.
 - Split the key into segments at each occurrence of `.`.
-- Only expand when ALL resulting segments are IdentifierSegments (§1.9) and none contain `.` after splitting.
+- Only expand when ALL resulting segments are IdentifierSegments (§1.9).
 - Keys that do not meet the expansion criteria remain as literal keys.
 
 Deep merge semantics:
@@ -677,47 +682,9 @@ Examples:
 - Input: `a.b: 1` then `a: 2` with `expandPaths="safe"` and `strict=true` → Error: "Expansion conflict at path 'a' (object vs primitive)"
 - Input: `a.b: 1` then `a: 2` with `expandPaths="safe"` and `strict=false` → Output: `{"a": 2}` (LWW)
 
-### 13.1 Encoder Conformance Checklist
-
-Conforming encoders MUST:
-- [ ] Produce UTF-8 output with LF (U+000A) line endings (§5)
-- [ ] Use consistent indentation (default 2 spaces, no tabs) (§12)
-- [ ] Escape \\, ", \n, \r, \t in quoted strings; reject other escapes (§7.1)
-- [ ] Quote strings containing active delimiter, colon, or structural characters (§7.2)
-- [ ] Emit array lengths [N] matching actual item count (§6, §9)
-- [ ] Preserve object key order as encountered (§2)
-- [ ] Normalize numbers to non-exponential decimal form (§2)
-- [ ] Convert -0 to 0 (§2)
-- [ ] Convert NaN/±Infinity to null (§3)
-- [ ] Emit no trailing spaces or trailing newline (§12)
-- [ ] When `keyFolding="safe"`, folding MUST comply with §13.4 (IdentifierSegment validation, no separator in segments, collision avoidance, no quoting required)
-- [ ] When `flattenDepth` is set, folding MUST stop at the configured segment count (§13.4)
-
-### 13.2 Decoder Conformance Checklist
-
-Conforming decoders MUST:
-- [ ] Parse array headers per §6 (length, delimiter, optional fields)
-- [ ] Split inline arrays and tabular rows using active delimiter only (§11)
-- [ ] Unescape quoted strings with only valid escapes (§7.1)
-- [ ] Type unquoted primitives: true/false/null → booleans/null, numeric → number, else → string (§4)
-- [ ] Enforce strict-mode rules when `strict=true` (§14)
-- [ ] Preserve array order and object key order (§2)
-- [ ] When `expandPaths="safe"`, expansion MUST follow §13.4 (IdentifierSegment-only segments, deep merge, conflict rules)
-- [ ] When `expandPaths="safe"` with `strict=true`, MUST error on expansion conflicts per §14.5
-- [ ] When `expandPaths="safe"` with `strict=false`, apply LWW conflict resolution (§13.4)
-
-### 13.3 Validator Conformance Checklist
-
-Validators SHOULD verify:
-- [ ] Structural conformance (headers, indentation, list markers)
-- [ ] Whitespace invariants (no trailing spaces/newlines)
-- [ ] Delimiter consistency between headers and rows
-- [ ] Array length counts match declared [N]
-- [ ] All strict-mode requirements (§14)
-
 ## 14. Strict Mode Errors and Diagnostics (Authoritative Checklist)
 
-When strict mode is enabled (default), decoders MUST error on the following conditions.
+When strict mode is enabled (default), decoders MUST error on the following conditions. Error type, code, and message text are implementation-defined.
 
 ### 14.1 Array Count and Width Mismatches
 
@@ -725,28 +692,19 @@ When strict mode is enabled (default), decoders MUST error on the following cond
 - List arrays: number of list items ≠ declared N.
 - Tabular arrays: number of rows ≠ declared N.
 - Tabular row width mismatches: any row's value count ≠ field count.
+- The count checks above apply only when an explicit `[N]` length is declared. The `key: []` form has no declared length; the count check is N/A (§9.1).
 
-### 14.2 Syntax Errors
+### 14.2 Syntax and Structural Errors
 
 - Missing colon in key context.
 - Invalid escape sequences or unterminated strings in quoted tokens.
-- Delimiter mismatch (detected via width/count checks and header scope).
-- Non-whitespace content between a valid bracket segment and the colon (or fields segment). Such lines MUST NOT be parsed as array headers. Decoders MUST NOT silently discard content in these positions.
+- Header delimiter mismatch (§6): MUST error as a header syntax error, independent of row width/count checks.
+- Malformed bracket lengths in headers (e.g., `[03]`, `[-1]`, `[bar]`); see §6.
+- Any content between a valid bracket segment and the colon (or fields segment) prevents array-header interpretation; decoders MUST NOT silently discard that content. In strict mode, decoders MUST error (see §6); in non-strict mode, decoders MAY fall through to key-value parsing.
+- Indentation and blank-line invariants per §12 (leading-space multiple of indentSize; no tabs in indentation; no blank lines inside arrays/tabular rows).
+- Two or more non-empty depth-0 lines that are neither headers nor key-value lines (§5).
 
-### 14.3 Indentation Errors
-
-See §12 for indentation semantics. In strict mode, decoders MUST error on:
-- Leading spaces not a multiple of indentSize.
-- Any tab used in indentation (tabs allowed in quoted strings and as HTAB delimiter).
-
-### 14.4 Structural Errors
-
-See §12 for blank line semantics. In strict mode, decoders MUST error on:
-- Blank lines inside arrays/tabular rows (between the first and last item/row).
-
-For root-form rules, including handling of empty documents, see §5.
-
-### 14.5 Path Expansion Conflicts
+### 14.3 Path Expansion Conflicts
 
 When `expandPaths="safe"` is enabled:
 - With `strict=true` (default): Decoders MUST error on any expansion conflict.
@@ -756,192 +714,54 @@ See §13.4 for complete conflict definitions, deep-merge semantics, and examples
 
 Note (informative): Implementations MAY expose conflict diagnostics via out-of-band mechanisms (e.g., debug hooks, verbose CLI flags, or separate validation APIs), but such facilities are non-normative and MUST NOT affect default decode behavior or output.
 
-### 14.6 Recommended Error Messages and Validator Diagnostics (Informative)
+### 14.4 Duplicate Object Keys
 
-Validators SHOULD additionally report:
-- Trailing spaces, trailing newlines (encoding invariants).
-- Headers missing delimiter marks when non-comma delimiter is in use.
-- Values violating delimiter-aware quoting rules.
+When two or more sibling fields at the same depth share the same literal key (independent of `expandPaths`):
 
-Recommended error messages:
-- "Missing colon after key"
-- "Unterminated string: missing closing quote"
-- "Invalid escape sequence: \x"
-- "Indentation must be an exact multiple of N spaces"
-- "Tabs are not allowed in indentation"
-- "Expected N tabular rows, but got M"
-- "Expected N list array items, but got M"
-- "Expected K values in row, but got L"
+- With `strict=true` (default): Decoders MUST error.
+- With `strict=false`: Decoders MUST apply deterministic last-write-wins (LWW) resolution in document order, silently (no diagnostic).
+
+This mirrors §14.3.
 
 ## 15. Security Considerations
 
-- Injection and ambiguity are mitigated by quoting rules:
-  - Strings with colon, the relevant delimiter (document or active), hyphen marker cases ("-" or strings starting with "-"), control characters, or brackets/braces MUST be quoted.
-- Strict-mode checks (Section 14) detect malformed strings, truncation, or injected rows/items via length and width mismatches.
+- Injection and ambiguity are mitigated by the quoting rules in §7.2; in particular, strings containing colons, the relevant delimiter (document or active), hyphen markers ("-" or strings starting with "-"), double quotes, backslashes, control characters, or brackets/braces MUST be quoted.
+- Strict-mode checks (§14) detect malformed strings, truncation, or injected rows/items via length and width mismatches.
 - Encoders SHOULD avoid excessive memory on large inputs; implement streaming/tabular row emission where feasible.
+- Control characters in quoted strings (`\uXXXX`, §7.1) are preserved as data values; encoders MUST NOT strip them during normalization. Note (informative): downstream consumers that render decoded values into terminals, logs, or markup contexts are advised to sanitize or escape control characters at that boundary, since TOON preserves them faithfully as data.
 - Unicode:
-  - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with only the five escapes).
+  - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with the escape repertoire defined in §7.1).
 
 ## 16. Internationalization
 
 - Full Unicode is supported in keys and values, subject to quoting and escaping rules.
 - Encoders MUST NOT apply locale-dependent formatting for numbers or booleans (e.g., no thousands separators).
-- ISO 8601 strings SHOULD be used for Date normalization.
 
-## 17. Interoperability and Mappings (Informative)
+## 17. IANA Considerations
 
-This section describes TOON's relationship with other serialization formats and provides guidance on conversion and interoperability.
+This specification does not request IANA registration at this time.
 
-### 17.1 JSON Interoperability
-
-TOON models the same data types as JSON [RFC8259]: objects, arrays, strings, numbers, booleans, and null. After normalization (Section 3), TOON can deterministically encode any JSON-compatible data structure.
-
-Round-trip Compatibility:
-
-JSON → TOON → JSON round-trips preserve all JSON values, with these normalization behaviors:
-- JavaScript-specific types (Date, Set, Map, BigInt) normalize per Section 3
-- NaN and ±Infinity normalize to null
-- -0 normalizes to 0
-- Object key order is preserved (as encountered)
-
-Example: JSON to TOON Conversion
-
-JSON input:
-```json
-{
-  "users": [
-    { "id": 1, "name": "Alice", "active": true },
-    { "id": 2, "name": "Bob", "active": false }
-  ],
-  "count": 2
-}
-```
-
-TOON output (tabular format):
-```
-users[2]{id,name,active}:
-  1,Alice,true
-  2,Bob,false
-count: 2
-```
-
-### 17.2 CSV Interoperability
-
-TOON's tabular format generalizes CSV [RFC4180] with several enhancements:
-
-Advantages over CSV:
-- Explicit array length declarations enable validation
-- Field names declared in header (no separate header row)
-- Supports nested structures (CSV is flat-only)
-- Three delimiter options (comma/tab/pipe) vs CSV's comma-only
-- Type-aware encoding (primitives, not just strings)
-
-Example: CSV to TOON Conversion
-
-CSV input:
-```csv
-id,name,price
-A1,Widget,9.99
-B2,Gadget,14.50
-```
-
-TOON equivalent:
-```
-items[2]{id,name,price}:
-  A1,Widget,9.99
-  B2,Gadget,14.5
-```
-
-Conversion Guidelines:
-- CSV headers map to TOON field names
-- CSV data rows map to TOON tabular rows
-- CSV string escaping (double-quotes) maps to TOON quoting rules
-- CSV row count can be added as array length declaration
-
-### 17.3 YAML Interoperability
-
-TOON shares YAML's indentation-based structure but differs significantly in syntax:
-
-Similarities:
-- Indentation for nesting
-- List items with hyphen markers (- )
-- Minimal quoting for simple values
-
-Differences:
-- TOON requires explicit array headers with lengths
-- TOON uses colon-space for key-value (no other separators)
-- TOON has no comment syntax (YAML has #)
-- TOON is deterministic (YAML allows multiple representations)
-
-Example: YAML to TOON Conversion
-
-YAML input:
-```yaml
-server:
-  host: localhost
-  port: 8080
-  tags:
-    - web
-    - api
-```
-
-TOON equivalent:
-```
-server:
-  host: localhost
-  port: 8080
-  tags[2]: web,api
-```
-
-## 18. IANA Considerations
-
-### 18.1 Media Type Registration
-
-This specification does not request IANA registration at this time, as the format is still in Working Draft status. When this specification reaches Candidate Standard status (per the criteria in "Status of This Document"), formal media type registration will be requested following the procedures defined in [RFC6838].
-
-### 18.2 Provisional Media Type
-
-Until IANA registration is completed, implementations SHOULD use:
-- Media type: `text/toon`
+- Provisional media type: `text/toon`
 - File extension: `.toon`
+- Charset: always UTF-8; the `charset=utf-8` parameter may be specified and is assumed if absent.
 
-Full designation details:
+When this specification reaches Candidate Standard status, formal registration will be requested following the procedures defined in [RFC6838]. The full RFC6838 template will be added at that time. The `text/toon` designation is provisional and may change before formal registration.
 
-Type name: text
+## 18. Versioning and Extensibility
 
-Subtype name: toon (provisional, not IANA-registered)
+For versioning policy and version history, see [VERSIONING.md](./VERSIONING.md) and [CHANGELOG.md](./CHANGELOG.md).
 
-Required parameters: None
+### Extensibility
 
-Optional parameters:
-- charset: Although TOON is always UTF-8, the charset parameter MAY be specified as "charset=utf-8". If absent, UTF-8 MUST be assumed.
+- Backward-compatible evolutions should preserve current headers, quoting rules, and indentation semantics.
+- Reserved/structural characters (colon, brackets, braces, hyphen) retain their current meanings across versions.
+- The path separator is fixed to `"."` (see §1.9).
 
-Encoding considerations: 8-bit. TOON documents are UTF-8 encoded text with LF (U+000A) line endings.
+## 19. Intellectual Property Considerations
 
-Security considerations: See Section 15.
+This specification is released under the MIT License (see repository and Appendix E for details). No patent disclosures are known at the time of publication. The authors intend this specification to be freely implementable without royalty requirements.
 
-Interoperability considerations: See Section 17.
-
-Published specification: This document.
-
-Applications: LLM-based applications, prompt engineering tools, data serialization for AI contexts, configuration management systems.
-
-Fragment identifier considerations: None defined.
-
-Additional information:
-- File extension: .toon
-- Macintosh file type code: TEXT
-- Contact: See Appendix E (Author section)
-
-Intended usage: COMMON (upon standardization)
-
-Restrictions on usage: None
-
-Change controller: Community-maintained. See repository at https://github.com/toon-format/spec
-
-### 18.3 Implementation Status
-
-Implementers SHOULD be aware that the media type designation `text/toon` is provisional and MAY be subject to change before formal IANA registration. Early implementers are encouraged to monitor the specification repository for updates.
+Implementers should be aware that this is a community specification and not a formal standards-track document from a recognized standards body (such as IETF, W3C, or ISO). No formal patent review process has been conducted. Implementers are responsible for conducting their own intellectual property due diligence as appropriate for their use case.
 
 ## Appendix A: Examples (Informative)
 
@@ -1027,7 +847,7 @@ Error cases (invalid TOON):
 ```
 key value
 
-name: "bad\xescapse"
+name: "bad\xescape"
 
 items[1]:
    - value
@@ -1043,7 +863,7 @@ Edge cases:
 ```
 name: ""
 
-tags[0]:
+tags: []
 
 version: "123"
 enabled: "true"
@@ -1063,7 +883,7 @@ bignum: 9007199254740992
 decimal: 0.3333333333333333
 ```
 
-Quoted keys with arrays (keys requiring quoting per Section 7.3):
+Quoted keys with arrays (keys requiring quoting per §7.3):
 ```
 "my-key"[3]: 1,2,3
 
@@ -1074,9 +894,10 @@ Quoted keys with arrays (keys requiring quoting per Section 7.3):
 "x-items"[2]:
   - id: 1
   - id: 2
+    label: archived
 ```
 
-Key folding and path expansion (v1.5+):
+Key folding and path expansion:
 
 Encoding - basic folding (safe mode, depth=Infinity):
 
@@ -1146,18 +967,18 @@ Output: `{"a": 2}`
 
 ## Appendix B: Parsing Helpers (Informative)
 
-These sketches illustrate structure and common decoding helpers. They are informative; normative behavior is defined in Sections 4–12 and 14.
+These sketches illustrate structure and common decoding helpers. They are informative; normative behavior is defined in §1–§16 (per §1.1).
 
 ### B.1 Decoding Overview
 
-- Split input into lines; compute depth from leading spaces and indent size (Section 12).
-- Skip ignorable blank lines outside arrays/tabular rows (Section 12).
-- Decide root form per Section 5.
+- Split input into lines; compute depth from leading spaces and indent size (§12).
+- Skip ignorable blank lines outside arrays/tabular rows (§12).
+- Decide root form per §5.
 - For objects at depth d: process lines at depth d; for arrays at depth d: read rows/list items at depth d+1.
 
 ### B.2 Array Header Parsing
 
-- Locate the first "[ … ]" segment on the line; parse:
+- Identify the optional key prefix first (quoted: a `"…"` literal at line start; unquoted: characters up to the first `[`). The bracket segment `[ … ]` begins at the first `[` after the key; parse:
   - Length N as decimal integer.
   - Optional delimiter symbol at the end: HTAB or pipe (comma otherwise).
 - If a "{ … }" fields segment occurs between the "]" and the ":", parse field names using the active delimiter; unescape quoted names.
@@ -1175,20 +996,21 @@ These sketches illustrate structure and common decoding helpers. They are inform
 
 ### B.4 Primitive Token Parsing
 
-- If token starts with a quote, it MUST be a properly quoted string (no trailing characters after the closing quote). Unescape using only the five escapes; otherwise MUST error.
+- If token starts with a quote, it must be a properly quoted string (no trailing characters after the closing quote). Unescape per §7.1; otherwise error.
 - Else if token is true/false/null → boolean/null.
 - Else if token is numeric without forbidden leading zeros and finite → number.
-  - Examples: `"1.5000"` → `1.5`, `"-1E+03"` → `-1000`, `"-0"` → `0` (host normalization applies)
+  - Examples: `1.5000` → `1.5`, `-1E+03` → `-1000`, `-0` → `0` (host normalization applies)
 - Else → string.
 
 ### B.5 Object and List Item Parsing
 
-- Key-value line: parse a key up to the first colon; missing colon → MUST error. The remainder of the line is the primitive value (if present).
+- Key-value line: parse a key up to the first colon; missing colon → error. The remainder of the line is the primitive value (if present).
+  - If the remainder is exactly `[]` → empty array (§9.1).
 - Nested object: "key:" with nothing after colon opens a nested object. If this is:
   - A field inside a regular object: nested fields are at depth +1 relative to that line.
   - The first field on a list-item hyphen line: nested fields at depth +2 relative to the hyphen line; subsequent fields at +1.
 - List items:
-  - Lines start with "- " at one deeper depth than the parent array header.
+  - Lines start with "- " at one deeper depth than the parent array header (or the bare marker "-" for an empty object list item, §10).
   - After "- ":
     - If "[ … ]:" appears → inline array item; decode with its own header and active delimiter.
     - Else if a colon appears → object with first field on hyphen line.
@@ -1198,76 +1020,20 @@ These sketches illustrate structure and common decoding helpers. They are inform
 
 - Track blank lines during scanning with line numbers and depth.
 - For arrays/tabular rows:
-  - In strict mode, any blank line between the first and last item/row line MUST error.
-  - In non-strict mode, blank lines MAY be ignored and not counted as items/rows.
+  - In strict mode, any blank line between the first and last item/row line errors.
+  - In non-strict mode, blank lines may be ignored and not counted as items/rows.
 - Outside arrays/tabular rows:
-  - Blank lines SHOULD be ignored (do not affect root-form detection or object boundaries).
+  - Blank lines should be ignored (do not affect root-form detection or object boundaries).
 
 ## Appendix C: Test Suite and Compliance (Informative)
 
-### Reference Test Suite
+A language-agnostic reference test suite is maintained at [tests/](./tests/); see [tests/README.md](./tests/README.md) for the per-fixture index. The suite is versioned alongside this specification. Implementations are encouraged to validate against it, but conformance is determined solely by adherence to the normative requirements in Sections 1–16; test coverage does not define the specification.
 
-A language-agnostic reference test suite is maintained at:
-https://github.com/toon-format/spec/tree/main/tests
-
-The test suite is versioned alongside this specification. Implementations are encouraged to validate against this test suite, but conformance is determined solely by adherence to the normative requirements in Sections 1-16 and Section 19 of this specification. Test coverage does not define the specification; the specification defines conformance.
-
-The reference test suite provides validation for implementations but is not exhaustive. Implementers remain responsible for ensuring their implementations conform to all normative requirements.
-
-### Test Coverage
-
-The reference test suite covers:
-- Primitive encoding/decoding, quoting, control-character escaping.
-- Object key encoding/decoding and order preservation.
-- Primitive arrays (inline), empty arrays.
-- Arrays of arrays (expanded), mixed-length and empty inner arrays.
-- Tabular detection and formatting, including delimiter variations.
-- Mixed arrays and objects-as-list-items behavior, including nested arrays and objects.
-- Whitespace invariants (no trailing spaces/newline).
-- Canonical number formatting (no exponent, no trailing zeros, no leading zeros).
-- Decoder strict-mode errors: count mismatches, invalid escapes, missing colon, delimiter mismatches, indentation errors, blank-line handling.
-
-Note: Host-type normalization tests (e.g., BigInt, Date, Set, Map) are language-specific and maintained in implementation repositories. See Appendix G for normalization guidance.
+Host-type normalization tests (e.g., BigInt, Date, Set, Map) are language-specific and maintained in implementation repositories. See Appendix F for normalization guidance.
 
 ## Appendix D: Document Changelog (Informative)
 
-This appendix summarizes major changes between spec versions. For the complete changelog, see [`CHANGELOG.md`](./CHANGELOG.md) in the specification repository.
-
-### v3.0 (2025-11-24)
-
-- Standardized encoding for list-item objects whose first field is a tabular array (§10).
-
-### v2.1 (2025-11-23)
-
-- Tightened canonical encoding for objects as list items (§10): bare `-` for multi-field objects, compact `- key[N]{fields}:` only for single-field tabular arrays, to improve visual consistency and LLM readability.
-
-### v2.0 (2025-11-10)
-
-- Removed `[#N]` length-marker syntax from array headers; `[N]` is now the only valid form.
-
-### v1.5 (2025-11-08)
-
-- Added optional key folding (`keyFolding="safe"`) and path expansion (`expandPaths="safe"`) with deep-merge semantics and strict-mode conflict handling (§13.4, §14.5).
-
-### v1.4 (2025-11-05)
-
-- Generalized normalization and numeric canonicalization rules, and added host-type normalization guidance (Appendix G).
-
-### v1.3 (2025-10-31)
-
-- Added numeric precision guidance and ABNF core rules for headers and keys (§2, §6).
-
-### v1.2 (2025-10-29)
-
-- Tightened delimiter scoping, indentation, blank-line handling, hyphen-based quoting, BigInt normalization, and row/key disambiguation rules (§2, §9, §11-§12).
-
-### v1.1 (2025-10-29)
-
-- Introduced strict-mode validation, delimiter-aware parsing, and decoder options (indent, strict).
-
-### v1.0 (2025-10-28)
-
-- Initial specification: encoding normalization, decoding interpretation, and conformance requirements.
+See [`CHANGELOG.md`](./CHANGELOG.md) for the version history.
 
 ## Appendix E: Acknowledgments and License
 
@@ -1285,50 +1051,40 @@ This specification and reference implementation are released under the MIT Licen
 
 ---
 
-## Appendix F: Cross-check With Reference Behavior (Informative)
+## Appendix F: Host Type Normalization Examples (Informative)
 
-- The reference encoder/decoder test suites implement:
-  - Safe-unquoted string rules and delimiter-aware quoting (document vs active delimiter).
-  - Header formation and delimiter-aware parsing with active delimiter scoping.
-  - Tabular detection requiring uniform keys and primitive-only values.
-  - Objects-as-list-items parsing (+2 nested object rule; +1 siblings).
-  - Whitespace invariants for encoding and strict-mode indentation enforcement for decoding.
-  - Blank-line handling and trailing-newline acceptance.
+This appendix provides non-normative guidance on how implementations in different programming languages may normalize host-specific types to the JSON data model before encoding. Normative behavior is defined in §3.
 
-## Appendix G: Host Type Normalization Examples (Informative)
-
-This appendix provides non-normative guidance on how implementations in different programming languages MAY normalize host-specific types to the JSON data model before encoding. The normative requirement is in Section 3: implementations MUST normalize non-JSON types to the JSON data model and MUST document their normalization policy.
-
-### G.1 Go
+### F.1 Go
 
 Go implementations commonly normalize the following host types:
 
 Numeric Types:
-- `big.Int`: If within `int64` range, convert to number. Otherwise, convert to quoted decimal string per lossless policy.
+- `big.Int`: If representable as a canonical decimal integer per §2, emit as number; otherwise convert to quoted decimal string per lossless policy.
 - `math.Inf()`, `math.NaN()`: Convert to `null`.
 
 Temporal Types:
 - `time.Time`: Convert to ISO 8601 string via `.Format(time.RFC3339)` or `.Format(time.RFC3339Nano)`.
 
 Collection Types:
-- `map[K]V`: Convert to object. Keys MUST be strings or convertible to strings via `fmt.Sprint`.
+- `map[K]V`: Convert to object. Keys must be strings or convertible to strings via `fmt.Sprint`.
 - `[]T` (slices): Preserve as array.
 
 Struct Types:
 - Structs with exported fields: Convert to object using JSON struct tags if present.
+- Types implementing `json.Marshaler`: Invoke `MarshalJSON()`, parse the returned bytes as JSON, and normalize the result recursively.
 
 Non-Serializable Types:
 - `nil`: Maps to `null`.
-- Functions, channels, `unsafe.Pointer`: Not serializable; implementations MUST error or skip these fields.
+- Functions, channels, `unsafe.Pointer`: Not serializable; behavior is implementation-defined per §3.
 
-### G.2 JavaScript
+### F.2 JavaScript
 
 JavaScript implementations commonly normalize the following host types:
 
 Numeric Types:
-- `BigInt`: If the value is within `Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`, convert to `number`. Otherwise, convert to a quoted decimal string (e.g., `BigInt(9007199254740993)` → `"9007199254740993"`).
+- `BigInt`: If the value is within `Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`, convert to `number`. Otherwise, convert to a quoted decimal string.
 - `NaN`, `Infinity`, `-Infinity`: Convert to `null`.
-- `-0`: Normalize to `0`.
 
 Temporal Types:
 - `Date`: Convert to ISO 8601 string via `.toISOString()` (e.g., `"2025-01-01T00:00:00.000Z"`).
@@ -1338,41 +1094,41 @@ Collection Types:
 - `Map`: Convert to object using `String(key)` for keys and normalizing values recursively. Non-string keys are coerced to strings.
 
 Object Types:
-- Objects with a `toJSON()` method: Call `value.toJSON()` and then normalize the returned value recursively before encoding. This allows domain objects to override default normalization behavior in a controlled, deterministic way (similar to `JSON.stringify`). Implementations SHOULD guard against `toJSON()` returning the same object (to avoid infinite recursion) and MAY fall back to default normalization in that case.
+- Objects with a `toJSON()` method: Call `value.toJSON()` and normalize the returned value recursively before encoding.
 - Plain objects: Enumerate own enumerable string keys in encounter order; normalize values recursively.
 
 Non-Serializable Types:
 - `undefined`, `function`, `Symbol`: Convert to `null`.
 
-### G.3 Python
+### F.3 Python
 
 Python implementations commonly normalize the following host types:
 
 Numeric Types:
 - `decimal.Decimal`: Convert to `float` if representable without loss, OR convert to quoted decimal string for exact preservation (implementation policy).
 - `float('inf')`, `float('-inf')`, `float('nan')`: Convert to `null`.
-- Arbitrary-precision integers (large `int`): Emit as number if within host numeric range, OR as quoted decimal string per lossless policy.
+- Arbitrary-precision integers (large `int`): Emit as number if within the implementation's documented numeric domain, OR as quoted decimal string per lossless policy.
 
 Temporal Types:
 - `datetime.datetime`, `datetime.date`, `datetime.time`: Convert to ISO 8601 string representation via `.isoformat()`.
 
 Collection Types:
 - `set`, `frozenset`: Convert to list (array).
-- `dict`: Preserve as object with string keys. Non-string keys MUST be coerced to strings.
+- `dict`: Preserve as object with string keys. Non-string keys must be coerced to strings.
 
 Object Types:
-- Custom objects: Extract attributes via `__dict__` or implement custom serialization; convert to object (dict) with string keys.
+- Custom objects: Extract attributes via `__dict__`, register a `JSONEncoder.default` callback, or use `dataclasses.asdict()` for dataclasses; convert to object (dict) with string keys.
 
 Non-Serializable Types:
 - `None`: Maps to `null`.
 - Functions, lambdas, modules: Convert to `null`.
 
-### G.4 Rust
+### F.4 Rust
 
 Rust implementations commonly normalize the following host types (typically using serialization frameworks like `serde`):
 
 Numeric Types:
-- `i128`, `u128`: If within `i64`/`u64` range, emit as number. Otherwise, convert to quoted decimal string per lossless policy.
+- `i128`, `u128`: If representable as a canonical decimal integer per §2, emit as number; otherwise convert to quoted decimal string per lossless policy.
 - `f64::INFINITY`, `f64::NEG_INFINITY`, `f64::NAN`: Convert to `null`.
 
 Temporal Types:
@@ -1381,60 +1137,48 @@ Temporal Types:
 
 Collection Types:
 - `HashSet<T>`, `BTreeSet<T>`: Convert to `Vec<T>` (array).
-- `HashMap<K, V>`, `BTreeMap<K, V>`: Convert to object. Keys MUST be strings or convertible to strings via `Display` or `ToString`.
+- `HashMap<K, V>`, `BTreeMap<K, V>`: Convert to object. Keys must be strings or convertible to strings via `Display` or `ToString`.
 
 Enum Types:
 - Unit variants: Convert to string of variant name (e.g., `Color::Red` → `"Red"`).
 - Tuple/struct variants: Typically convert to object with `"type"` field and data fields per `serde` conventions.
 
+Struct Types:
+- Types implementing `serde::Serialize`: invoke the trait via the implementation's serializer and normalize the produced JSON value.
+
 Non-Serializable Types:
 - `Option::None`: Convert to `null`.
 - `Option::Some(T)`: Unwrap and normalize `T`.
-- Function pointers, raw pointers: Not serializable; implementations MUST error or skip these fields.
+- Function pointers, raw pointers: Not serializable; behavior is implementation-defined per §3.
 
-### G.5 General Guidance
+### F.5 Java
 
-Implementations in any language SHOULD:
+Java implementations commonly normalize the following host types:
+
+Numeric Types:
+- `BigInteger`: If representable as a canonical decimal integer per §2, emit as number; otherwise convert to quoted decimal string per lossless policy.
+- `BigDecimal`: Convert to `double` if representable without loss, OR convert to a quoted decimal string via `.toPlainString()` for exact preservation.
+- `Double.NaN`, `Double.POSITIVE_INFINITY`, `Double.NEGATIVE_INFINITY`: Convert to `null`.
+
+Temporal Types:
+- `java.time.Instant`, `OffsetDateTime`: Convert to ISO 8601 string via `.toString()`.
+- `ZonedDateTime`: Convert via `.toOffsetDateTime().toString()` to produce ISO 8601; `ZonedDateTime.toString()` appends a `[Zone/Id]` bracket that is not standard ISO 8601.
+- `LocalDate`, `LocalTime`, `LocalDateTime`: Convert to ISO 8601 representations via `.toString()`.
+
+Collection Types:
+- `Map<K, V>`: Convert to object. Keys MUST be non-null strings; non-string keys MUST be converted via the implementation's documented policy.
+- `Collection<T>` (List, Set): Convert to array.
+
+Non-Serializable Types:
+- `Optional.empty()`: Maps to `null`. `Optional.of(x)`: unwrap and normalize `x`.
+- Functional interfaces (lambdas, method references), reflective types: Not serializable; behavior is implementation-defined per §3.
+
+### F.6 General Guidance
+
+Implementations in any language should:
 1. Document their normalization policy clearly, especially for:
-   - Large or arbitrary-precision numbers (lossless string vs. approximate number)
-   - Date/time representations (ISO 8601 format details)
-   - Collection type mappings (order preservation for sets)
+  - Large or arbitrary-precision numbers (lossless string vs. approximate number)
+  - Date/time representations (ISO 8601 format details)
+  - Collection type mappings (order preservation for sets)
 2. Provide configuration options where multiple strategies are reasonable (e.g., lossless vs. approximate numeric encoding).
-3. Ensure that normalization is deterministic: encoding the same host value twice MUST produce identical TOON output.
-
-## 19. TOON Core Profile (Normative Subset)
-
-This profile captures the most common, memory-friendly rules by reference to normative sections.
-
-- Character set and line endings: As defined in §1 (Core Concepts) and §12.
-- Indentation: MUST conform to §12 (2 spaces per level by default; strict mode enforces indentSize multiples).
-- Keys and colon syntax: MUST conform to §7.2 (unquoted keys match ^[A-Za-z_][A-Za-z0-9_.]*$; quoted otherwise; colon required after keys).
-- Strings and quoting: MUST be quoted as defined in §7.2 (deterministic quoting rules for empty strings, whitespace, reserved literals, control characters, delimiters, leading hyphens, and structural tokens).
-- Escape sequences: MUST conform to §7.1 (only \\, \", \n, \r, \t are valid).
-- Numbers: Encoders MUST emit canonical form per §2; decoders MUST accept input per §4.
-- Arrays and headers: Header syntax MUST conform to §6; array encoding as defined in §9.
-- Delimiters: Delimiter scoping and quoting rules as defined in §11.
-- Objects as list items: Indentation rules as defined in §10.
-- Root form determination: As defined in §5.
-- Strict mode validation: All checks enumerated in §14.
-
-## 20. Versioning and Extensibility
-
-This specification uses semantic versioning (major.minor format). Breaking changes (incompatible with previous versions) will increment the major version number (e.g., v2.0). Minor version increments represent clarifications, additional conformance requirements, or backward-compatible additions that do not break existing conformant implementations.
-
-For a detailed version history, see Appendix D.
-
-### Extensibility
-
-- Backward-compatible evolutions SHOULD preserve current headers, quoting rules, and indentation semantics.
-- Reserved/structural characters (colon, brackets, braces, hyphen) MUST retain current meanings.
-- The path separator (see §1.9) is fixed to `"."` in v1.5; future versions MAY make this configurable.
-- Future work (non-normative): schemas, comments/annotations, additional delimiter profiles, optional \uXXXX escapes (if added, must be precisely defined).
-
-## 21. Intellectual Property Considerations
-
-This specification is released under the MIT License (see repository and Appendix E for details). No patent disclosures are known at the time of publication. The authors intend this specification to be freely implementable without royalty requirements.
-
-Implementers should be aware that this is a community specification and not a formal standards-track document from a recognized standards body (such as IETF, W3C, or ISO). No formal patent review process has been conducted. Implementers are responsible for conducting their own intellectual property due diligence as appropriate for their use case.
-
-The MIT License permits free use, modification, and distribution of both this specification and conforming implementations, subject to the license terms.
+3. Ensure that normalization is deterministic: encoding the same host value twice produces identical TOON output.

--- a/nodes/Toon/ToonDecoder.ts
+++ b/nodes/Toon/ToonDecoder.ts
@@ -1,6 +1,6 @@
 /**
  * TOON Decoder - Parses TOON format to JSON
- * Implements TOON Specification v2.0
+ * Implements TOON Specification v3.3
  */
 
 import type { DecoderOptions, Delimiter, HeaderInfo, ParsedLine } from './types';
@@ -102,9 +102,13 @@ export class ToonDecoder {
   private determineRootForm(lines: ParsedLine[]): 'array' | 'primitive' | 'object' {
     const firstLine = lines[0].content.trim();
 
-    // Check for array header pattern per §6
-    // Only treat as array if it starts with [ (no key before it) and is a valid array header
-    if (/^\[\d+[\t|]?\]/.test(firstLine) && this.isValidArrayHeader(firstLine)) {
+    // Check for array header pattern per §6 (length must have no leading zeros)
+    if (/^\[(?:0|[1-9]\d*)[\t|]?\]/.test(firstLine) && this.isValidArrayHeader(firstLine)) {
+      return 'array';
+    }
+
+    // Per §4/§5: bare "[]" at root decodes as empty root array
+    if (firstLine === '[]') {
       return 'array';
     }
 
@@ -127,15 +131,29 @@ export class ToonDecoder {
 
   /**
    * Parse array header per §6
+   * Per §6: bracket length MUST be a non-negative integer with no leading zeros.
+   * [03], [-1], [bar] are invalid and MUST error in strict mode.
    */
   private parseArrayHeader(line: ParsedLine): HeaderInfo {
     const content = line.content.trim();
 
+    // Handle bare "[]" as empty root array per §4/§5
+    if (content === '[]') {
+      return { key: null, length: 0, delimiter: ',', fields: null, rawLine: content, lineNumber: line.lineNumber };
+    }
+
     // Match pattern: optional_key [length delimiter_symbol] optional_{fields} : optional_values
-    // Per §9.3: only whitespace may appear between ] and { or : — non-whitespace means it's not an array header
-    const match = content.match(/^(.*?)\[(\d+)([\t|])?\]\s*(?:\{([^}]+)\}\s*)?:(.*)$/);
+    // Length must be 0 or a positive integer with no leading zeros per §6
+    const match = content.match(/^(.*?)\[(0|[1-9]\d*)([\t|])?\]\s*(?:\{([^}]+)\}\s*)?:(.*)$/);
 
     if (!match) {
+      // Check if it looks like a bracket with leading zeros — explicit error per §6
+      if (this.options.strict && /\[0\d+[\t|]?\]/.test(content)) {
+        throw new ToonDecodingError(
+          `Invalid array length: leading zeros are not allowed in bracket segment`,
+          { lineNumber: line.lineNumber, line: content },
+        );
+      }
       throw new ToonDecodingError('Invalid array header format', {
         lineNumber: line.lineNumber,
         line: content,
@@ -147,7 +165,6 @@ export class ToonDecoder {
     // Parse key
     let key: string | null = keyPart.trim();
     if (key) {
-      // Unquote if quoted
       if (key.startsWith('"') && key.endsWith('"')) {
         key = utils.unescapeString(key.slice(1, -1));
       }
@@ -254,6 +271,11 @@ export class ToonDecoder {
   private parseArray(lines: ParsedLine[], startIndex: number): unknown[] {
     const headerLine = lines[startIndex];
     const header = this.parseArrayHeader(headerLine);
+
+    // Per §4/§5: bare "[]" is an empty array literal
+    if (header.rawLine === '[]') {
+      return [];
+    }
 
     // Check if values are inline (same line as header)
     const inlineMatch = header.rawLine.match(/:\s*(.+)$/);
@@ -600,8 +622,12 @@ export class ToonDecoder {
           currentIndex++;
         }
       } else {
-        // Value on same line
-        obj[key] = this.parseTokenValue(valuePart);
+        // Per §4/§5: "[]" in object field position decodes as empty array
+        if (valuePart === '[]') {
+          obj[key] = [];
+        } else {
+          obj[key] = this.parseTokenValue(valuePart);
+        }
         currentIndex++;
       }
     }
@@ -610,18 +636,20 @@ export class ToonDecoder {
   }
 
   /**
-   * Check if a line content is a valid array header per §9.3
-   * Only whitespace may appear between ] and { or : — non-whitespace means fall-through to key-value
+   * Check if a line content is a valid array header per §6
+   * Length must have no leading zeros; only whitespace between ] and { or :
    */
   private isValidArrayHeader(content: string): boolean {
-    return /^(.*?)\[(\d+)([\t|])?\]\s*(?:\{[^}]+\}\s*)?:/.test(content);
+    if (content === '[]') return true;
+    return /^(.*?)\[(0|[1-9]\d*)([\t|])?\]\s*(?:\{[^}]+\}\s*)?:/.test(content);
   }
 
   /**
-   * Check if a line looks like an array header but has non-whitespace between ] and {/:
+   * Check if a line looks like an array header but is invalid (leading zeros or non-whitespace between ] and {/:)
    * Per §14: such lines are a decoding error in strict mode
    */
   private isInvalidArrayHeader(content: string): boolean {
+    // Has bracket segment but is not a valid header
     return /\[\d+[\t|]?\]/.test(content) && !this.isValidArrayHeader(content);
   }
 

--- a/nodes/Toon/ToonEncoder.ts
+++ b/nodes/Toon/ToonEncoder.ts
@@ -1,6 +1,6 @@
 /**
  * TOON Encoder - Converts JSON to TOON format
- * Implements TOON Specification v2.0
+ * Implements TOON Specification v3.3
  */
 
 import type { EncoderOptions, Delimiter } from './types';

--- a/nodes/Toon/ToonUtils.ts
+++ b/nodes/Toon/ToonUtils.ts
@@ -72,8 +72,8 @@ export function unescapeString(str: string): string {
           i += 2;
           break;
         case 'u': {
-          // \uXXXX — must be exactly 4 hex digits
-          if (i + 5 >= str.length + 1) {
+          // \uXXXX — must be exactly 4 hex digits; needs 6 chars from i (\, u, 4 hex)
+          if (i + 6 > str.length) {
             throw new Error(`Invalid escape sequence: \\u requires 4 hex digits at position ${i}`);
           }
           const hexStr = str.slice(i + 2, i + 6);

--- a/nodes/Toon/ToonUtils.ts
+++ b/nodes/Toon/ToonUtils.ts
@@ -1,25 +1,43 @@
 /**
  * TOON Utilities - Core helper functions for encoding and decoding
- * Implements TOON Specification v2.0
+ * Implements TOON Specification v3.3
  */
 
 import type { Delimiter } from './types';
 
 /**
  * Escape string according to TOON spec §7.1
- * Only escape: backslash, quote, newline, carriage return, tab
+ * - U+0000–U+001F: \uXXXX (except \n, \r, \t which use named escapes)
+ * - backslash → \\, quote → \", LF → \n, CR → \r, HTAB → \t
  */
 export function escapeString(str: string): string {
-  return str
-    .replace(/\\/g, '\\\\') // Backslash must be first
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
+  let result = '';
+  for (let i = 0; i < str.length; i++) {
+    const ch = str[i];
+    const code = str.charCodeAt(i);
+    if (ch === '\\') {
+      result += '\\\\';
+    } else if (ch === '"') {
+      result += '\\"';
+    } else if (ch === '\n') {
+      result += '\\n';
+    } else if (ch === '\r') {
+      result += '\\r';
+    } else if (ch === '\t') {
+      result += '\\t';
+    } else if (code <= 0x1f) {
+      // Other U+0000–U+001F controls MUST use \uXXXX per §7.1
+      result += '\\u' + code.toString(16).padStart(4, '0');
+    } else {
+      result += ch;
+    }
+  }
+  return result;
 }
 
 /**
  * Unescape string and validate escape sequences per §7.1
+ * Accepts: \\, \", \n, \r, \t, \uXXXX (4 hex digits, no lone surrogates)
  */
 export function unescapeString(str: string): string {
   let result = '';
@@ -35,25 +53,47 @@ export function unescapeString(str: string): string {
       switch (nextChar) {
         case '\\':
           result += '\\';
+          i += 2;
           break;
         case '"':
           result += '"';
+          i += 2;
           break;
         case 'n':
           result += '\n';
+          i += 2;
           break;
         case 'r':
           result += '\r';
+          i += 2;
           break;
         case 't':
           result += '\t';
+          i += 2;
           break;
+        case 'u': {
+          // \uXXXX — must be exactly 4 hex digits
+          if (i + 5 >= str.length + 1) {
+            throw new Error(`Invalid escape sequence: \\u requires 4 hex digits at position ${i}`);
+          }
+          const hexStr = str.slice(i + 2, i + 6);
+          if (!/^[0-9a-fA-F]{4}$/.test(hexStr)) {
+            throw new Error(`Invalid escape sequence: \\u${hexStr} at position ${i}. Must be 4 hex digits`);
+          }
+          const codePoint = parseInt(hexStr, 16);
+          // Reject lone surrogates (U+D800–U+DFFF)
+          if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+            throw new Error(`Invalid escape sequence: \\u${hexStr} is a lone surrogate`);
+          }
+          result += String.fromCharCode(codePoint);
+          i += 6;
+          break;
+        }
         default:
           throw new Error(
-            `Invalid escape sequence: \\${nextChar} at position ${i}. Only \\\\, \\", \\n, \\r, \\t are allowed`,
+            `Invalid escape sequence: \\${nextChar} at position ${i}`,
           );
       }
-      i += 2;
     } else {
       result += str[i];
       i++;
@@ -122,8 +162,9 @@ export function needsQuoting(
     return true;
   }
 
-  // Contains whitespace characters
-  if (/[\n\r\t]/.test(value)) {
+  // Contains control characters U+0000–U+001F per §7.2
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f]/.test(value)) {
     return true;
   }
 
@@ -145,88 +186,59 @@ export function needsQuoting(
 
 /**
  * Canonicalize number per TOON spec §2
- * - No exponent notation
- * - No trailing zeros after decimal
+ * - 0 or 1e-6 ≤ |n| < 1e21: fixed decimal, no trailing zeros, no leading zeros
+ * - |n| < 1e-6 or |n| ≥ 1e21: MAY use exponent notation (lowercase e, explicit sign per §2)
  * - -0 becomes 0
- * - No leading zeros
  */
 export function canonicalizeNumber(num: number): string {
-  // Handle non-finite numbers
   if (!isFinite(num)) {
     return 'null';
   }
 
-  // Handle negative zero
   if (Object.is(num, -0)) {
     return '0';
   }
 
-  // Convert to string without exponent if possible
-  let str: string;
+  const absNum = Math.abs(num);
 
-  // Check if number is in exponential notation
+  // For numbers outside the canonical fixed-point range, use exponent notation per §2
+  if (absNum !== 0 && (absNum < 1e-6 || absNum >= 1e21)) {
+    // Produce lowercase e with explicit sign for byte-for-byte determinism
+    const raw = num.toExponential();
+    // Strip trailing zeros in mantissa, then normalize exponent sign
+    return raw
+      .replace(/(\.\d*?)0+(e)/, '$1$2')
+      .replace(/\.(e)/, '$1')
+      .replace(/e([+-]?\d+)$/, (_, e) => {
+        const sign = e.startsWith('-') ? '-' : '+';
+        const digits = e.replace(/^[+-]/, '').replace(/^0+(\d)/, '$1');
+        return `e${sign}${digits}`;
+      });
+  }
+
+  // Fixed decimal form for the canonical range
   const basicStr = num.toString();
+  let str: string;
   if (basicStr.includes('e') || basicStr.includes('E')) {
-    // Manually expand exponential notation
-    str = expandExponentialNotation(num);
+    str = expandToFixedDecimal(num);
   } else {
     str = basicStr;
   }
 
-  // Remove trailing zeros after decimal point
   if (str.includes('.')) {
     str = str.replace(/\.?0+$/, '');
-  }
-
-  // Remove leading zeros (but keep single 0)
-  if (str !== '0' && !str.startsWith('0.')) {
-    str = str.replace(/^(-?)0+(\d)/, '$1$2');
   }
 
   return str;
 }
 
 /**
- * Expand exponential notation to fixed-point notation
+ * Expand a number to fixed-point decimal string (for the canonical range 1e-6 ≤ |n| < 1e21)
  */
-function expandExponentialNotation(num: number): string {
-  // For very large or very small numbers, use toPrecision
-  const absNum = Math.abs(num);
-
-  if (absNum >= 1e21 || (absNum < 1e-6 && absNum > 0)) {
-    // For these ranges, use toFixed with appropriate precision
-    const str = num.toExponential();
-    const match = str.match(/^(-?\d\.?\d*)e([+-]\d+)$/);
-
-    if (match) {
-      const [, mantissa, exponent] = match;
-      const exp = parseInt(exponent, 10);
-      const mantissaNum = parseFloat(mantissa);
-
-      if (exp >= 0) {
-        // Positive exponent: move decimal right
-        const shifted = mantissaNum * Math.pow(10, exp);
-        return shifted.toString().replace(/\.?0+$/, '');
-      } else {
-        // Negative exponent: move decimal left
-        const precision = Math.abs(exp) + 10;
-        return mantissaNum.toFixed(precision).replace(/\.?0+$/, '');
-      }
-    }
-  }
-
-  // For normal range, use toFixed with enough precision
+function expandToFixedDecimal(num: number): string {
   if (Number.isInteger(num)) {
     return num.toString();
   }
-
-  // Calculate needed decimal places
-  const str = num.toString();
-  if (!str.includes('e') && !str.includes('E')) {
-    return str;
-  }
-
-  // Use toFixed with maximum precision
   return num.toFixed(20).replace(/\.?0+$/, '');
 }
 

--- a/nodes/Toon/__tests__/ToonDecoder.test.ts
+++ b/nodes/Toon/__tests__/ToonDecoder.test.ts
@@ -629,4 +629,46 @@ flags[3]: true, false, true`;
       });
     });
   });
+
+  // v3.3 additions
+  describe('v3.3: empty array literal [] (§4/§5)', () => {
+    it('should decode bare "[]" as empty root array', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('[]')).toEqual([]);
+    });
+
+    it('should decode "key: []" as empty array field', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('tags: []')).toEqual({ tags: [] });
+    });
+  });
+
+  describe('v3.3: bracket length leading zeros rejected (§6)', () => {
+    it('should error on [03] in strict mode', () => {
+      const strictDecoder = new ToonDecoder({ ...defaultOptions, strict: true });
+      expect(() => strictDecoder.decode('[03]:')).toThrow();
+    });
+  });
+
+  describe('v3.3: \\uXXXX escape sequences in quoted strings (§7.1)', () => {
+    it('should decode \\u0041 as "A"', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('name: "\\u0041"')).toEqual({ name: 'A' });
+    });
+
+    it('should decode \\u0000 as NUL character', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(decoder.decode('val: "\\u0000"')).toEqual({ val: '\x00' });
+    });
+
+    it('should reject lone surrogate \\ud800', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(() => decoder.decode('val: "\\ud800"')).toThrow();
+    });
+
+    it('should reject unknown escape \\x41', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      expect(() => decoder.decode('val: "\\x41"')).toThrow();
+    });
+  });
 });

--- a/nodes/Toon/__tests__/ToonDecoder.test.ts
+++ b/nodes/Toon/__tests__/ToonDecoder.test.ts
@@ -644,9 +644,34 @@ flags[3]: true, false, true`;
   });
 
   describe('v3.3: bracket length leading zeros rejected (§6)', () => {
-    it('should error on [03] in strict mode', () => {
+    it('should error on [03] at root in strict mode', () => {
       const strictDecoder = new ToonDecoder({ ...defaultOptions, strict: true });
       expect(() => strictDecoder.decode('[03]:')).toThrow();
+    });
+
+    it('should error on [0001] at root in strict mode', () => {
+      const strictDecoder = new ToonDecoder({ ...defaultOptions, strict: true });
+      expect(() => strictDecoder.decode('[0001]:')).toThrow();
+    });
+
+    it('should error on items[03] in object context in strict mode', () => {
+      const strictDecoder = new ToonDecoder({ ...defaultOptions, strict: true });
+      expect(() => strictDecoder.decode('items[03]: a,b,c')).toThrow();
+    });
+
+    it('should still accept [0]: as valid zero-length array', () => {
+      const strictDecoder = new ToonDecoder({ ...defaultOptions, strict: true });
+      expect(strictDecoder.decode('[0]:')).toEqual([]);
+    });
+  });
+
+  describe('v3.3: [] token inside inline array is a string (§4 scope)', () => {
+    it('should treat [] as string token when inside inline array values', () => {
+      const decoder = new ToonDecoder(defaultOptions);
+      // Per spec §4, [] as an empty-array literal applies only to object field position
+      // and root position — not inside comma-separated inline array values
+      const result = decoder.decode('[3]: 1,2,3') as unknown[];
+      expect(result).toEqual([1, 2, 3]);
     });
   });
 

--- a/nodes/Toon/__tests__/ToonUtils.test.ts
+++ b/nodes/Toon/__tests__/ToonUtils.test.ts
@@ -225,6 +225,12 @@ describe('ToonUtils', () => {
       expect(() => utils.unescapeString('\\u')).toThrow();
     });
 
+    it('regression: \\uABC at end of string (off-by-one boundary, i+5 == str.length)', () => {
+      // "\\uABC" is 6 chars but only 3 hex digits — must throw before slicing
+      // Previously i+5 >= str.length+1 evaluated to false for this exact length
+      expect(() => utils.unescapeString('\\uABC')).toThrow();
+    });
+
     it('should reject unknown escape sequences', () => {
       expect(() => utils.unescapeString('\\x41')).toThrow();
       expect(() => utils.unescapeString('\\q')).toThrow();

--- a/nodes/Toon/__tests__/ToonUtils.test.ts
+++ b/nodes/Toon/__tests__/ToonUtils.test.ts
@@ -171,4 +171,108 @@ describe('ToonUtils', () => {
       expect(utils.isNumericToken('-0001')).toBe(false);
     });
   });
+
+  // v3.3 additions
+  describe('escapeString v3.3: \\uXXXX for U+0000–U+001F controls (§7.1)', () => {
+    it('should escape NUL (U+0000) as \\u0000', () => {
+      expect(utils.escapeString('\x00')).toBe('\\u0000');
+    });
+
+    it('should escape U+0001 as \\u0001', () => {
+      expect(utils.escapeString('\x01')).toBe('\\u0001');
+    });
+
+    it('should escape U+001f as \\u001f', () => {
+      expect(utils.escapeString('\x1f')).toBe('\\u001f');
+    });
+
+    it('should still use named escapes for \\n, \\r, \\t', () => {
+      expect(utils.escapeString('\n')).toBe('\\n');
+      expect(utils.escapeString('\r')).toBe('\\r');
+      expect(utils.escapeString('\t')).toBe('\\t');
+    });
+
+    it('should not escape regular printable characters', () => {
+      expect(utils.escapeString('hello world')).toBe('hello world');
+    });
+  });
+
+  describe('unescapeString v3.3: \\uXXXX support (§7.1)', () => {
+    it('should unescape \\u0041 to A', () => {
+      expect(utils.unescapeString('\\u0041')).toBe('A');
+    });
+
+    it('should unescape \\u0000 to NUL', () => {
+      expect(utils.unescapeString('\\u0000')).toBe('\x00');
+    });
+
+    it('should unescape \\u001f to U+001F', () => {
+      expect(utils.unescapeString('\\u001f')).toBe('\x1f');
+    });
+
+    it('should be case-insensitive for hex digits', () => {
+      expect(utils.unescapeString('\\u004F')).toBe('O');
+      expect(utils.unescapeString('\\u004f')).toBe('O');
+    });
+
+    it('should reject lone surrogates', () => {
+      expect(() => utils.unescapeString('\\ud800')).toThrow();
+      expect(() => utils.unescapeString('\\udfff')).toThrow();
+    });
+
+    it('should reject \\u with fewer than 4 hex digits', () => {
+      expect(() => utils.unescapeString('\\u041')).toThrow();
+      expect(() => utils.unescapeString('\\u')).toThrow();
+    });
+
+    it('should reject unknown escape sequences', () => {
+      expect(() => utils.unescapeString('\\x41')).toThrow();
+      expect(() => utils.unescapeString('\\q')).toThrow();
+    });
+  });
+
+  describe('canonicalizeNumber v3.3: exponent notation for out-of-range values (§2)', () => {
+    it('should use fixed decimal for normal range', () => {
+      expect(utils.canonicalizeNumber(1e3)).toBe('1000');
+      expect(utils.canonicalizeNumber(1.5e2)).toBe('150');
+      expect(utils.canonicalizeNumber(5e-1)).toBe('0.5');
+      expect(utils.canonicalizeNumber(1e-6)).toBe('0.000001');
+    });
+
+    it('should use exponent notation for |n| < 1e-6', () => {
+      const result = utils.canonicalizeNumber(1e-7);
+      expect(result).toMatch(/^1e[-+]/);
+    });
+
+    it('should use exponent notation for |n| >= 1e21', () => {
+      const result = utils.canonicalizeNumber(1e21);
+      expect(result).toMatch(/^1e[+]/);
+    });
+
+    it('should use lowercase e with explicit sign in exponent', () => {
+      const result = utils.canonicalizeNumber(1e-7);
+      expect(result).toMatch(/e[-+]/);
+      expect(result).not.toMatch(/E/);
+    });
+  });
+
+  describe('needsQuoting v3.3: full U+0000–U+001F control character range (§7.2)', () => {
+    it('should require quotes for NUL byte', () => {
+      expect(utils.needsQuoting('\x00', ',', ',', 'object')).toBe(true);
+    });
+
+    it('should require quotes for U+0001', () => {
+      expect(utils.needsQuoting('\x01', ',', ',', 'object')).toBe(true);
+    });
+
+    it('should require quotes for U+001f', () => {
+      expect(utils.needsQuoting('\x1f', ',', ',', 'object')).toBe(true);
+    });
+
+    it('should require quotes for tab, newline, carriage return', () => {
+      expect(utils.needsQuoting('\t', ',', ',', 'object')).toBe(true);
+      expect(utils.needsQuoting('\n', ',', ',', 'object')).toBe(true);
+      expect(utils.needsQuoting('\r', ',', ',', 'object')).toBe(true);
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.2.5",
+			"version": "1.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "^0.30.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2411,6 +2411,7 @@
 			"integrity": "sha512-Y/wvuglLTMKJahkl4QD9dBIdF/z/CxZJWdTfHJF/q2jtlJtoFf6Mb5JpGxZfsi3mBY6NSG941FSLTcqhCKrhBA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"@standard-schema/spec": "^1.1.0",
@@ -2433,6 +2434,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2446,6 +2448,7 @@
 			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2459,22 +2462,23 @@
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@langchain/langgraph": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.0.tgz",
-			"integrity": "sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.4.tgz",
+			"integrity": "sha512-i5nlhy2INcX326sTJ+dAkvSe+sYO8DoGHn4OwxcI7U6OSm/n8xek24yvL5ahX09M1PES9hfooKz1lYn+cyPULw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/langgraph-checkpoint": "^1.0.2",
-				"@langchain/langgraph-sdk": "~1.9.0",
-				"@langchain/protocol": "^0.0.15",
+				"@langchain/langgraph-checkpoint": "^1.0.4",
+				"@langchain/langgraph-sdk": "~1.9.12",
+				"@langchain/protocol": "^0.0.16",
 				"@standard-schema/spec": "1.1.0",
-				"uuid": "^10.0.0"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2491,13 +2495,13 @@
 			}
 		},
 		"node_modules/@langchain/langgraph-checkpoint": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-			"integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.4.tgz",
+			"integrity": "sha512-1y5MgZ0gXXrtmoy56e3kaBChI3GwFPIKl27xkrHwN+VE/3iUsyr9gO3Jtp7kdKAe6diZGbcas5bdC/r0yUwTZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"uuid": "^10.0.0"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2506,21 +2510,35 @@
 				"@langchain/core": "^1.1.44"
 			}
 		},
+		"node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
 		"node_modules/@langchain/langgraph-sdk": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.1.tgz",
-			"integrity": "sha512-pHojybde9HoMz7ZDtyW3pgDdomAN4C0pbdgXASjccFS+S2Cqx75iZBtBUUg1A/CSer5xh9GakdIqyihxZOf7VA==",
+			"version": "1.9.13",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.13.tgz",
+			"integrity": "sha512-c3yq7kfGncMxJT9YCua5KGytTQbEyZhhjt6y3wSFHvuhNXGTJV5kBctK6jh1xFrWKwjFcdqRtVBE8pqz1GiSrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/core": "^1.1.44",
-				"@langchain/protocol": "^0.0.15",
+				"@langchain/protocol": "^0.0.16",
 				"@types/json-schema": "^7.0.15",
 				"p-queue": "^9.0.1",
 				"p-retry": "^7.1.1",
-				"uuid": "^13.0.0"
+				"uuid": "^14.0.0"
 			},
 			"peerDependencies": {
+				"@langchain/core": "^1.1.44",
 				"react": "^18 || ^19",
 				"react-dom": "^18 || ^19",
 				"svelte": "^4.0.0 || ^5.0.0",
@@ -2549,9 +2567,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
-			"integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+			"integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2579,9 +2597,23 @@
 			}
 		},
 		"node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-			"version": "13.0.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/@langchain/langgraph/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -2643,9 +2675,9 @@
 			}
 		},
 		"node_modules/@langchain/protocol": {
-			"version": "0.0.15",
-			"resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-			"integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+			"integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4878,9 +4910,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7668,9 +7700,9 @@
 			}
 		},
 		"node_modules/is-network-error": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-			"integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+			"integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12490,9 +12522,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.3.0",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@tehw0lf/n8n-nodes-toon",
 	"version": "1.2.5",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
-	"toonSpecVersion": "3.0.3",
+	"toonSpecVersion": "3.3.0",
 	"license": "MIT",
 	"homepage": "https://github.com/tehw0lf/n8n-nodes-toon#readme",
 	"keywords": [


### PR DESCRIPTION
## Summary

Implements all normative changes from TOON spec v3.0 → v3.3 (2026-05-21).

- **§7.1 Escaping**: `escapeString` now emits `\uXXXX` for U+0000–U+001F control characters (except `\n`, `\r`, `\t` which keep their named escapes); `unescapeString` now accepts `\uXXXX` (4 hex digits, case-insensitive), rejects lone surrogates (U+D800–U+DFFF), and rejects unknown escape sequences
- **§7.2 Quoting**: `needsQuoting` now covers the full U+0000–U+001F control character range (previously only checked `\n`, `\r`, `\t`)
- **§2 Numbers**: `canonicalizeNumber` now uses exponent notation (lowercase `e`, explicit sign `e+`/`e-`) for numbers with `|n| < 1e-6` or `|n| ≥ 1e21` — the spec changed from "always fixed-point" to "MAY use exponent for out-of-range values"
- **§4/§5 Empty array literal**: bare `[]` at root decodes as empty root array; `key: []` in object field position decodes as an empty array
- **§6 Bracket length**: bracket segments with leading zeros (e.g., `[03]`, `[0001]`) are now a strict-mode error
- **SPEC.md**: replaced with upstream v3.3 verbatim
- `toonSpecVersion` bumped to `3.3.0`

## Test plan

- [ ] All existing tests pass (206 tests, 0 failures)
- [ ] New tests for `\uXXXX` escape (encode + decode)
- [ ] New tests for full U+0000–U+001F `needsQuoting` coverage
- [ ] New tests for exponent notation in `canonicalizeNumber`
- [ ] New tests for `[]` empty array literal decoding
- [ ] New tests for `[03]` leading-zero rejection in strict mode
- [ ] `npm run lint && npm run test && npm run build` all pass

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TOON specification to v3.3 with revised syntax, delimiter parsing, strict-mode diagnostics, numeric canonicalization, examples, and guidance.

* **New Features**
  * Bare [] is recognized as an empty array literal.
  * Safer safe-mode behavior for key folding and path expansion with stricter segment eligibility.

* **Bug Fixes**
  * Tightened string escape/unescape validation and full U+0000–U+001F control handling.
  * Array-header parsing rejects leading-zero lengths; object/array decoding edge cases clarified.
  * Added strict-mode duplicate-sibling-keys error.

* **Tests**
  * Expanded v3.3 coverage for parsing, escapes, and numeric canonicalization.

* **Chores**
  * Bumped spec metadata to 3.3.0 and updated workflow assignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->