### PR TITLE
fix(package): set n8n-workflow peer dependency to "*"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "^0.30.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
-				"n8n-workflow": "^2.7.0"
+				"n8n-workflow": "*"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
 		"typescript": "5.9.3"
 	},
 	"peerDependencies": {
-		"n8n-workflow": "^2.7.0"
+		"n8n-workflow": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.3.0",
 	"license": "MIT",
@@ -27,8 +27,8 @@
 		"build": "n8n-node build",
 		"build:watch": "tsc --watch",
 		"dev": "n8n-node dev",
-		"lint": "n8n-node lint",
-		"lint:fix": "n8n-node lint --fix",
+		"lint": "npx @n8n/node-cli@latest lint",
+		"lint:fix": "npx @n8n/node-cli@latest lint --fix",
 		"test": "jest"
 	},
 	"files": [


### PR DESCRIPTION
## Summary

- Changes `peerDependencies.n8n-workflow` from `^2.7.0` to `*`
- Required by n8n community node scanner: community nodes must declare `n8n-workflow: "*"` so the host n8n instance can satisfy it regardless of installed version
- Pre-existing issue flagged by n8n's pipeline since last release

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes (211/211)
- [ ] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released patch update (v1.3.1).
  * Broadened compatibility with n8n-workflow to support all versions.
  * Updated developer tooling for linting to use the latest CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->