### PR TITLE
chore(package): update version and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
       library_path: "dist"
       publish_github_release: "true"
       npm_audit_omit_dev: true
-      npm_audit_severity_threshold: "high"
+      npm_audit_severity_threshold: "critical"
       cyclonedx_ignore_npm_errors: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,7 +39,7 @@ jobs:
       tool: "npm"
       semgrep_rules: "auto p/security-audit p/owasp-top-ten p/ci p/nodejs p/typescript"
       npm_audit_omit_dev: true
-      npm_audit_severity_threshold: "high"
+      npm_audit_severity_threshold: "critical"
 
   # Download artifacts from latest CI build
   # Note: Reuses artifacts from the main CI workflow instead of rebuilding

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
 				"@n8n/node-cli": "0.35.1",
 				"@types/jest": "30.0.0",
 				"eslint": "9.29.0",
-				"jest": "30.4.2",
+				"jest": "30.2.0",
 				"prettier": "3.8.4",
-				"ts-jest": "29.4.11",
-				"typescript": "6.0.3"
+				"ts-jest": "29.4.6",
+				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
 				"n8n-workflow": "*"
@@ -1231,57 +1231,124 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
-			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
+			"integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
-				"jest-message-util": "30.4.1",
-				"jest-util": "30.4.1",
+				"jest-message-util": "30.2.0",
+				"jest-util": "30.2.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/core": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
-			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+		"node_modules/@jest/console/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.4.1",
-				"@jest/pattern": "30.4.0",
-				"@jest/reporters": "30.4.1",
-				"@jest/test-result": "30.4.1",
-				"@jest/transform": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/console/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/console/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/console/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/core": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
+			"integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.2.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/reporters": "30.2.0",
+				"@jest/test-result": "30.2.0",
+				"@jest/transform": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"exit-x": "^0.2.2",
-				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-changed-files": "30.4.1",
-				"jest-config": "30.4.2",
-				"jest-haste-map": "30.4.1",
-				"jest-message-util": "30.4.1",
-				"jest-regex-util": "30.4.0",
-				"jest-resolve": "30.4.1",
-				"jest-resolve-dependencies": "30.4.2",
-				"jest-runner": "30.4.2",
-				"jest-runtime": "30.4.2",
-				"jest-snapshot": "30.4.1",
-				"jest-util": "30.4.1",
-				"jest-validate": "30.4.1",
-				"jest-watcher": "30.4.1",
-				"pretty-format": "30.4.1",
+				"jest-changed-files": "30.2.0",
+				"jest-config": "30.2.0",
+				"jest-haste-map": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.2.0",
+				"jest-resolve-dependencies": "30.2.0",
+				"jest-runner": "30.2.0",
+				"jest-runtime": "30.2.0",
+				"jest-snapshot": "30.2.0",
+				"jest-util": "30.2.0",
+				"jest-validate": "30.2.0",
+				"jest-watcher": "30.2.0",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1296,6 +1363,73 @@
 				}
 			}
 		},
+		"node_modules/@jest/core/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/core/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/core/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/core/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@jest/diff-sequences": {
 			"version": "30.4.0",
 			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
@@ -1307,30 +1441,76 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
-				"jest-mock": "30.4.1"
+				"jest-mock": "30.2.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/expect": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
-			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+		"node_modules/@jest/environment/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "30.4.1",
-				"jest-snapshot": "30.4.1"
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/expect": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
+			"integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "30.2.0",
+				"jest-snapshot": "30.2.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1349,19 +1529,256 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/fake-timers": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+		"node_modules/@jest/expect/node_modules/@jest/diff-sequences": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/@jest/expect-utils": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.4.1",
-				"@sinonjs/fake-timers": "^15.4.0",
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/expect": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "30.2.0",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/jest-diff": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.0.1",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/jest-matcher-utils": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.2.0",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
-				"jest-message-util": "30.4.1",
-				"jest-mock": "30.4.1",
-				"jest-util": "30.4.1"
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/expect/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@sinonjs/fake-timers": "^13.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/fake-timers/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1378,62 +1795,108 @@
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
-			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+			"integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.4.1",
-				"@jest/expect": "30.4.1",
-				"@jest/types": "30.4.1",
-				"jest-mock": "30.4.1"
+				"@jest/environment": "30.2.0",
+				"@jest/expect": "30.2.0",
+				"@jest/types": "30.2.0",
+				"jest-mock": "30.2.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/@jest/globals/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/globals/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/globals/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/@jest/pattern": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
-				"jest-regex-util": "30.4.0"
+				"jest-regex-util": "30.0.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
-			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
+			"integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.4.1",
-				"@jest/test-result": "30.4.1",
-				"@jest/transform": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/console": "30.2.0",
+				"@jest/test-result": "30.2.0",
+				"@jest/transform": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"collect-v8-coverage": "^1.0.2",
 				"exit-x": "^0.2.2",
-				"glob": "^10.5.0",
+				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "30.4.1",
-				"jest-util": "30.4.1",
-				"jest-worker": "30.4.1",
+				"jest-message-util": "30.2.0",
+				"jest-util": "30.2.0",
+				"jest-worker": "30.2.0",
 				"slash": "^3.0.0",
 				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
@@ -1450,10 +1913,77 @@
 				}
 			}
 		},
+		"node_modules/@jest/reporters/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1464,13 +1994,13 @@
 			}
 		},
 		"node_modules/@jest/snapshot-utils": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
-			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
+			"integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"natural-compare": "^1.4.0"
@@ -1495,14 +2025,14 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
-			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
+			"integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/console": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"collect-v8-coverage": "^1.0.2"
 			},
@@ -1511,15 +2041,15 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
-			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
+			"integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.4.1",
+				"@jest/test-result": "30.2.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.4.1",
+				"jest-haste-map": "30.2.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1527,23 +2057,24 @@
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
-			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
+			"integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"babel-plugin-istanbul": "^7.0.1",
 				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.4.1",
-				"jest-regex-util": "30.4.0",
-				"jest-util": "30.4.1",
+				"jest-haste-map": "30.2.0",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.2.0",
+				"micromatch": "^4.0.8",
 				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
 				"write-file-atomic": "^5.0.1"
@@ -1552,15 +2083,46 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/types": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+		"node_modules/@jest/transform/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/pattern": "30.4.0",
-				"@jest/schemas": "30.4.1",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/transform/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
@@ -3070,9 +3632,9 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "15.4.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
-			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4061,19 +4623,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4203,16 +4752,16 @@
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
+			"integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "30.4.1",
+				"@jest/transform": "30.2.0",
 				"@types/babel__core": "^7.20.5",
 				"babel-plugin-istanbul": "^7.0.1",
-				"babel-preset-jest": "30.4.0",
+				"babel-preset-jest": "30.2.0",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
@@ -4245,9 +4794,9 @@
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
+			"integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4285,13 +4834,13 @@
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
+			"integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-plugin-jest-hoist": "30.2.0",
 				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
@@ -6149,24 +6698,6 @@
 				"bser": "2.1.1"
 			}
 		},
-		"node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7389,16 +7920,16 @@
 			"license": "ISC"
 		},
 		"node_modules/jest": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
-			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
+			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.4.2",
-				"@jest/types": "30.4.1",
+				"@jest/core": "30.2.0",
+				"@jest/types": "30.2.0",
 				"import-local": "^3.2.0",
-				"jest-cli": "30.4.2"
+				"jest-cli": "30.2.0"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -7416,44 +7947,75 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
-			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
+			"integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"execa": "^5.1.1",
-				"jest-util": "30.4.1",
+				"jest-util": "30.2.0",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-circus": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
-			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+		"node_modules/jest-changed-files/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.4.1",
-				"@jest/expect": "30.4.1",
-				"@jest/test-result": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-changed-files/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-circus": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
+			"integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.2.0",
+				"@jest/expect": "30.2.0",
+				"@jest/test-result": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"co": "^4.6.0",
 				"dedent": "^1.6.0",
 				"is-generator-fn": "^2.1.0",
-				"jest-each": "30.4.1",
-				"jest-matcher-utils": "30.4.1",
-				"jest-message-util": "30.4.1",
-				"jest-runtime": "30.4.2",
-				"jest-snapshot": "30.4.1",
-				"jest-util": "30.4.1",
+				"jest-each": "30.2.0",
+				"jest-matcher-utils": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-runtime": "30.2.0",
+				"jest-snapshot": "30.2.0",
+				"jest-util": "30.2.0",
 				"p-limit": "^3.1.0",
-				"pretty-format": "30.4.1",
+				"pretty-format": "30.2.0",
 				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
@@ -7462,22 +8024,131 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-cli": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
-			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+		"node_modules/jest-circus/node_modules/@jest/diff-sequences": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-diff": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.4.2",
-				"@jest/test-result": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/diff-sequences": "30.0.1",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-matcher-utils": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.2.0",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-circus/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-cli": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
+			"integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.2.0",
+				"@jest/test-result": "30.2.0",
+				"@jest/types": "30.2.0",
 				"chalk": "^4.1.2",
 				"exit-x": "^0.2.2",
 				"import-local": "^3.2.0",
-				"jest-config": "30.4.2",
-				"jest-util": "30.4.1",
-				"jest-validate": "30.4.1",
+				"jest-config": "30.2.0",
+				"jest-util": "30.2.0",
+				"jest-validate": "30.2.0",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -7495,34 +8166,66 @@
 				}
 			}
 		},
+		"node_modules/jest-cli/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-cli/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/jest-config": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
-			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
+			"integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
 				"@jest/get-type": "30.1.0",
-				"@jest/pattern": "30.4.0",
-				"@jest/test-sequencer": "30.4.1",
-				"@jest/types": "30.4.1",
-				"babel-jest": "30.4.1",
+				"@jest/pattern": "30.0.1",
+				"@jest/test-sequencer": "30.2.0",
+				"@jest/types": "30.2.0",
+				"babel-jest": "30.2.0",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"deepmerge": "^4.3.1",
-				"glob": "^10.5.0",
+				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.4.2",
-				"jest-docblock": "30.4.0",
-				"jest-environment-node": "30.4.1",
-				"jest-regex-util": "30.4.0",
-				"jest-resolve": "30.4.1",
-				"jest-runner": "30.4.2",
-				"jest-util": "30.4.1",
-				"jest-validate": "30.4.1",
+				"jest-circus": "30.2.0",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.2.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.2.0",
+				"jest-runner": "30.2.0",
+				"jest-util": "30.2.0",
+				"jest-validate": "30.2.0",
+				"micromatch": "^4.0.8",
 				"parse-json": "^5.2.0",
-				"pretty-format": "30.4.1",
+				"pretty-format": "30.2.0",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -7546,6 +8249,52 @@
 				}
 			}
 		},
+		"node_modules/jest-config/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-config/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-config/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/jest-diff": {
 			"version": "30.4.1",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
@@ -7563,9 +8312,9 @@
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
-			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7576,57 +8325,149 @@
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
-			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
+			"integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
 				"chalk": "^4.1.2",
-				"jest-util": "30.4.1",
-				"pretty-format": "30.4.1"
+				"jest-util": "30.2.0",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-each/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-each/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-each/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
+			"integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.4.1",
-				"@jest/fake-timers": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/environment": "30.2.0",
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
-				"jest-mock": "30.4.1",
-				"jest-util": "30.4.1",
-				"jest-validate": "30.4.1"
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0",
+				"jest-validate": "30.2.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-haste-map": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
-			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+		"node_modules/jest-environment-node/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-haste-map": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
+			"integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"anymatch": "^3.1.3",
 				"fb-watchman": "^2.0.2",
 				"graceful-fs": "^4.2.11",
-				"jest-regex-util": "30.4.0",
-				"jest-util": "30.4.1",
-				"jest-worker": "30.4.1",
-				"picomatch": "^4.0.3",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.2.0",
+				"jest-worker": "30.2.0",
+				"micromatch": "^4.0.8",
 				"walker": "^1.0.8"
 			},
 			"engines": {
@@ -7636,15 +8477,61 @@
 				"fsevents": "^2.3.3"
 			}
 		},
+		"node_modules/jest-haste-map/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/jest-leak-detector": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
-			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
+			"integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"pretty-format": "30.4.1"
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-leak-detector/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7688,6 +8575,75 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/jest-message-util/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/jest-mock": {
 			"version": "30.4.1",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
@@ -7699,6 +8655,62 @@
 				"@types/node": "*",
 				"jest-util": "30.4.1"
 			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
@@ -7722,9 +8734,9 @@
 			}
 		},
 		"node_modules/jest-regex-util": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7732,18 +8744,18 @@
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
-			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
+			"integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.4.1",
+				"jest-haste-map": "30.2.0",
 				"jest-pnp-resolver": "^1.2.3",
-				"jest-util": "30.4.1",
-				"jest-validate": "30.4.1",
+				"jest-util": "30.2.0",
+				"jest-validate": "30.2.0",
 				"slash": "^3.0.0",
 				"unrs-resolver": "^1.7.11"
 			},
@@ -7752,46 +8764,77 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
-			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
+			"integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-regex-util": "30.4.0",
-				"jest-snapshot": "30.4.1"
+				"jest-regex-util": "30.0.1",
+				"jest-snapshot": "30.2.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runner": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
-			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+		"node_modules/jest-resolve/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.4.1",
-				"@jest/environment": "30.4.1",
-				"@jest/test-result": "30.4.1",
-				"@jest/transform": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-runner": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
+			"integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.2.0",
+				"@jest/environment": "30.2.0",
+				"@jest/test-result": "30.2.0",
+				"@jest/transform": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
-				"jest-docblock": "30.4.0",
-				"jest-environment-node": "30.4.1",
-				"jest-haste-map": "30.4.1",
-				"jest-leak-detector": "30.4.1",
-				"jest-message-util": "30.4.1",
-				"jest-resolve": "30.4.1",
-				"jest-runtime": "30.4.2",
-				"jest-util": "30.4.1",
-				"jest-watcher": "30.4.1",
-				"jest-worker": "30.4.1",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.2.0",
+				"jest-haste-map": "30.2.0",
+				"jest-leak-detector": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-resolve": "30.2.0",
+				"jest-runtime": "30.2.0",
+				"jest-util": "30.2.0",
+				"jest-watcher": "30.2.0",
+				"jest-worker": "30.2.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
@@ -7799,33 +8842,100 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runtime": {
-			"version": "30.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
-			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+		"node_modules/jest-runner/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.4.1",
-				"@jest/fake-timers": "30.4.1",
-				"@jest/globals": "30.4.1",
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-runner/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
+			"integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.2.0",
+				"@jest/fake-timers": "30.2.0",
+				"@jest/globals": "30.2.0",
 				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.4.1",
-				"@jest/transform": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/test-result": "30.2.0",
+				"@jest/transform": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"cjs-module-lexer": "^2.1.0",
 				"collect-v8-coverage": "^1.0.2",
-				"glob": "^10.5.0",
+				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.4.1",
-				"jest-message-util": "30.4.1",
-				"jest-mock": "30.4.1",
-				"jest-regex-util": "30.4.0",
-				"jest-resolve": "30.4.1",
-				"jest-snapshot": "30.4.1",
-				"jest-util": "30.4.1",
+				"jest-haste-map": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.2.0",
+				"jest-snapshot": "30.2.0",
+				"jest-util": "30.2.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
@@ -7833,10 +8943,92 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/jest-runtime/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/jest-snapshot": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
-			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
+			"integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7845,22 +9037,177 @@
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1",
 				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.4.1",
+				"@jest/expect-utils": "30.2.0",
 				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.4.1",
-				"@jest/transform": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/snapshot-utils": "30.2.0",
+				"@jest/transform": "30.2.0",
+				"@jest/types": "30.2.0",
 				"babel-preset-current-node-syntax": "^1.2.0",
 				"chalk": "^4.1.2",
-				"expect": "30.4.1",
+				"expect": "30.2.0",
 				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.4.1",
-				"jest-matcher-utils": "30.4.1",
-				"jest-message-util": "30.4.1",
-				"jest-util": "30.4.1",
-				"pretty-format": "30.4.1",
+				"jest-diff": "30.2.0",
+				"jest-matcher-utils": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-util": "30.2.0",
+				"pretty-format": "30.2.0",
 				"semver": "^7.7.2",
 				"synckit": "^0.11.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/@jest/diff-sequences": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/@jest/expect-utils": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/expect": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "30.2.0",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.2.0",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/jest-diff": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.0.1",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.2.0",
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7884,59 +9231,205 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-validate": {
+		"node_modules/jest-util/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/@jest/schemas": {
 			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
-			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-validate": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
+			"integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.4.1",
+				"@jest/types": "30.2.0",
 				"camelcase": "^6.3.0",
 				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "30.4.1"
+				"pretty-format": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
-			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
+			"integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.4.1",
-				"@jest/types": "30.4.1",
+				"@jest/test-result": "30.2.0",
+				"@jest/types": "30.2.0",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "30.4.1",
+				"jest-util": "30.2.0",
 				"string-length": "^4.0.2"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/jest-watcher/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-watcher/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/jest-worker": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
-			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
+			"integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"@ungap/structured-clone": "^1.3.0",
-				"jest-util": "30.4.1",
+				"jest-util": "30.2.0",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.1.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jmespath": {
@@ -8506,19 +9999,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/mime-db": {
@@ -9217,13 +10697,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -9420,6 +10900,19 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/pretty-format/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9509,6 +11002,13 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT"
+		},
+		"node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/react-is-18": {
@@ -10304,6 +11804,37 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/title-case": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -10429,19 +11960,19 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.11",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-			"integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+			"version": "29.4.6",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+			"integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
 				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.9",
+				"handlebars": "^4.7.8",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.8.0",
+				"semver": "^7.7.3",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -10458,7 +11989,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <7"
+				"typescript": ">=4.3 <6"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -10548,9 +12079,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.3.1",
+			"version": "1.3.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@n8n/node-cli": "^0.30.1",
+				"@n8n/node-cli": "0.35.1",
 				"@types/jest": "30.0.0",
-				"eslint": "9.39.2",
-				"jest": "30.2.0",
-				"prettier": "3.8.1",
-				"ts-jest": "29.4.6",
-				"typescript": "5.9.3"
+				"eslint": "9.29.0",
+				"jest": "30.4.2",
+				"prettier": "3.8.4",
+				"ts-jest": "29.4.11",
+				"typescript": "6.0.3"
 			},
 			"peerDependencies": {
 				"n8n-workflow": "*"
@@ -38,33 +38,14 @@
 				"node-fetch": "^2.6.7"
 			}
 		},
-		"node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -80,9 +61,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -90,21 +71,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -131,14 +112,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -148,14 +129,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -175,9 +156,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -185,29 +166,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -217,9 +198,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+			"integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -227,9 +208,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -237,9 +218,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -247,9 +228,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -257,27 +238,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -342,13 +323,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+			"integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
+				"@babel/helper-plugin-utils": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -384,13 +365,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+			"integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
+				"@babel/helper-plugin-utils": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -510,13 +491,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+			"integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
+				"@babel/helper-plugin-utils": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -526,33 +507,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -560,14 +541,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -593,9 +574,9 @@
 			}
 		},
 		"node_modules/@browserbasehq/sdk": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.10.0.tgz",
-			"integrity": "sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.14.1.tgz",
+			"integrity": "sha512-Ahmzb5+82ePgSGwouKEoAhiGy8mJ3RbCl+uigfGfVc60zseYIftcMiDPXSmrTQr1NHaATRx4cJlynP8ZUweXtg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -607,25 +588,6 @@
 				"formdata-node": "^4.3.2",
 				"node-fetch": "^2.6.7"
 			}
-		},
-		"node_modules/@browserbasehq/sdk/node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/@browserbasehq/sdk/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@browserbasehq/stagehand": {
 			"version": "1.14.0",
@@ -687,32 +649,6 @@
 				"@clack/core": "0.5.0",
 				"picocolors": "^1.0.0",
 				"sisteransi": "^1.0.5"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -779,15 +715,15 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+			"integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^2.1.7",
+				"@eslint/object-schema": "^2.1.6",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.5"
+				"minimatch": "^3.1.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -801,9 +737,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -825,22 +761,19 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+			"integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@eslint/core": "^0.17.0"
-			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+			"integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -882,9 +815,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -906,9 +839,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+			"version": "9.29.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+			"integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -929,14 +862,27 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.17.0",
+				"@eslint/core": "^0.15.2",
 				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1006,9 +952,9 @@
 			"peer": true
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1069,41 +1015,19 @@
 			}
 		},
 		"node_modules/@ibm-cloud/watsonx-ai": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.11.tgz",
-			"integrity": "sha512-sBMj/YhV5qvJdBpvgutmX6vLUUnSwvhFaJk7r3hiMh5aB7BQWQ+5zyzvSPLywOwTWZbgy4v8jxTUhR6jb+kguw==",
+			"version": "1.7.14",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.14.tgz",
+			"integrity": "sha512-nP0ayzuck6gDpL5ohkI7t3ExXPfF0TICyO/QroGbW7lKd996Rzzls1+X9gZE3B6xQLbCJz9/AsM+YhE+dcnY5g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@types/node": "^18.0.0",
-				"extend": "3.0.2",
 				"form-data": "^4.0.4",
-				"ibm-cloud-sdk-core": "^5.4.9",
-				"ts-node": "^10.9.2"
+				"ibm-cloud-sdk-core": "^5.4.20"
 			},
 			"engines": {
 				"node": ">=20.0.0"
 			}
-		},
-		"node_modules/@ibm-cloud/watsonx-ai/node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/@ibm-cloud/watsonx-ai/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -1206,6 +1130,16 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1297,137 +1231,57 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
-			"integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/console/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/console/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/console/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/core": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
-			"integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/pattern": "30.0.1",
-				"@jest/reporters": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-changed-files": "30.2.0",
-				"jest-config": "30.2.0",
-				"jest-haste-map": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-resolve-dependencies": "30.2.0",
-				"jest-runner": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
-				"jest-watcher": "30.2.0",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1442,90 +1296,10 @@
 				}
 			}
 		},
-		"node_modules/@jest/core/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/core/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/core/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/core/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/core/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/diff-sequences": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+			"integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1533,370 +1307,61 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "30.2.0"
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@jest/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "30.2.0",
-				"jest-snapshot": "30.2.0"
+				"expect": "30.4.1",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect-utils": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-			"integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+			"integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/@jest/expect-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "30.2.0",
-				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@sinonjs/fake-timers": "^13.0.0",
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
 				"@types/node": "*",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1913,108 +1378,62 @@
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-			"integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/expect": "30.2.0",
-				"@jest/types": "30.2.0",
-				"jest-mock": "30.2.0"
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/types": "30.4.1",
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@jest/pattern": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
-				"jest-regex-util": "30.0.1"
+				"jest-regex-util": "30.4.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
-			"integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"collect-v8-coverage": "^1.0.2",
 				"exit-x": "^0.2.2",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-worker": "30.2.0",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
 				"slash": "^3.0.0",
 				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
@@ -2031,90 +1450,10 @@
 				}
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/schemas": {
-			"version": "30.0.5",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2125,13 +1464,13 @@
 			}
 		},
 		"node_modules/@jest/snapshot-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
-			"integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"natural-compare": "^1.4.0"
@@ -2156,14 +1495,14 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
-			"integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"collect-v8-coverage": "^1.0.2"
 			},
@@ -2172,15 +1511,15 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
-			"integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.2.0",
+				"@jest/test-result": "30.4.1",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -2188,24 +1527,23 @@
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-			"integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"babel-plugin-istanbul": "^7.0.1",
 				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-util": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
 				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
 				"write-file-atomic": "^5.0.1"
@@ -2214,46 +1552,15 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/transform/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/transform/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/@jest/types": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.5",
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
@@ -2374,14 +1681,11 @@
 			}
 		},
 		"node_modules/@langchain/classic/node_modules/openai": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
-			"integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
+			"integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -2406,18 +1710,15 @@
 			}
 		},
 		"node_modules/@langchain/core": {
-			"version": "1.1.45",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.45.tgz",
-			"integrity": "sha512-Y/wvuglLTMKJahkl4QD9dBIdF/z/CxZJWdTfHJF/q2jtlJtoFf6Mb5JpGxZfsi3mBY6NSG941FSLTcqhCKrhBA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.0.tgz",
+			"integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"@standard-schema/spec": "^1.1.0",
-				"ansi-styles": "^5.0.0",
-				"camelcase": "6",
-				"decamelize": "1.2.0",
 				"js-tiktoken": "^1.0.12",
 				"langsmith": ">=0.5.0 <1.0.0",
 				"mustache": "^4.2.0",
@@ -2426,34 +1727,6 @@
 			},
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/@langchain/core/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@langchain/core/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@langchain/core/node_modules/zod": {
@@ -2468,23 +1741,22 @@
 			}
 		},
 		"node_modules/@langchain/langgraph": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.4.tgz",
-			"integrity": "sha512-i5nlhy2INcX326sTJ+dAkvSe+sYO8DoGHn4OwxcI7U6OSm/n8xek24yvL5ahX09M1PES9hfooKz1lYn+cyPULw==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.4.tgz",
+			"integrity": "sha512-20p+/xHRIUIEkk6dsoA576X7D5+FY+LkShsGjBpKrwATzQU0IJ2dfpBaP+4Z4wwpL9ArpDxjoRQR58kycdxU8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/langgraph-checkpoint": "^1.0.4",
-				"@langchain/langgraph-sdk": "~1.9.12",
+				"@langchain/langgraph-checkpoint": "^1.1.2",
+				"@langchain/langgraph-sdk": "~1.9.23",
 				"@langchain/protocol": "^0.0.16",
-				"@standard-schema/spec": "1.1.0",
-				"uuid": "^14.0.0"
+				"@standard-schema/spec": "1.1.0"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@langchain/core": "^1.1.44",
+				"@langchain/core": "^1.1.48",
 				"zod": "^3.25.32 || ^4.2.0",
 				"zod-to-json-schema": "^3.x"
 			},
@@ -2495,50 +1767,32 @@
 			}
 		},
 		"node_modules/@langchain/langgraph-checkpoint": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.4.tgz",
-			"integrity": "sha512-1y5MgZ0gXXrtmoy56e3kaBChI3GwFPIKl27xkrHwN+VE/3iUsyr9gO3Jtp7kdKAe6diZGbcas5bdC/r0yUwTZA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.2.tgz",
+			"integrity": "sha512-m5Xd7W3G9JrlEhFZ5WAcqZPgE46R9gr1gFDFaVqEKeuwin3tgEp0jlPbru+iFXCug338DcQjFS/Kuuci21ydvw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"uuid": "^14.0.0"
-			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@langchain/core": "^1.1.44"
-			}
-		},
-		"node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
+				"@langchain/core": "^1.1.48"
 			}
 		},
 		"node_modules/@langchain/langgraph-sdk": {
-			"version": "1.9.13",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.13.tgz",
-			"integrity": "sha512-c3yq7kfGncMxJT9YCua5KGytTQbEyZhhjt6y3wSFHvuhNXGTJV5kBctK6jh1xFrWKwjFcdqRtVBE8pqz1GiSrA==",
+			"version": "1.9.23",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.23.tgz",
+			"integrity": "sha512-JF5TWOrrKaMn9D7O0xT/9e9t3CpDRd8DUyKQdcbGswDsWdlI+04E9E1Lxv361tMu5pNYhval3iJPAwGxUuqi4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@langchain/protocol": "^0.0.16",
 				"@types/json-schema": "^7.0.15",
 				"p-queue": "^9.0.1",
-				"p-retry": "^7.1.1",
-				"uuid": "^14.0.0"
+				"p-retry": "^7.1.1"
 			},
 			"peerDependencies": {
-				"@langchain/core": "^1.1.44",
+				"@langchain/core": "^1.1.48",
 				"react": "^18 || ^19",
 				"react-dom": "^18 || ^19",
 				"svelte": "^4.0.0 || ^5.0.0",
@@ -2596,34 +1850,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
-		"node_modules/@langchain/langgraph/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"node_modules/@langchain/openai": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.4.tgz",
@@ -2643,14 +1869,11 @@
 			}
 		},
 		"node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
-			"integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
+			"integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -2697,30 +1920,20 @@
 				"@langchain/core": "^1.0.0"
 			}
 		},
-		"node_modules/@n8n_io/riot-tmpl": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
-			"integrity": "sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eslint-config-riot": "^1.0.0"
-			}
-		},
 		"node_modules/@n8n/ai-node-sdk": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.11.1.tgz",
-			"integrity": "sha512-De5Dy+yONKA8GeVE/UWBMmS4PVoxOlyX0fqSjp7vFnLqhKpdmQSk33eQH6tdZcOTVfZxl4P0WnLfJYBRRkpixg==",
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.16.1.tgz",
+			"integrity": "sha512-pXTDQxG2Q/6NCdIHS9IQt8XBwzItAIx8lzPT8mAFs+bzLtkDBQh61V/7dWHEBwfeKMkXjcuKqBEg7YpA9TSPbA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/ai-utilities": "0.14.1"
+				"@n8n/ai-utilities": "0.19.1"
 			}
 		},
 		"node_modules/@n8n/ai-utilities": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.14.1.tgz",
-			"integrity": "sha512-n5K5CjauxRNoc2sIX+fVICl4Z8LaO9jBwaP48/XWh6ckUj2JzQ05D52YFr7Y7g/j5h56AJgNb7UCv8+EqpCcWA==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.19.1.tgz",
+			"integrity": "sha512-QlKXt3Vt8fhUqBTP8dH+alCoFZaIKrqtk0Mp8UcOqxEY9klEwShihO2gNhXqVVx8yf/KWvnnhKsUYkV6w0mgZw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -2729,14 +1942,17 @@
 				"@langchain/core": "1.1.41",
 				"@langchain/openai": "1.4.4",
 				"@langchain/textsplitters": "1.0.1",
-				"@n8n/config": "2.19.1",
-				"@n8n/typescript-config": "1.4.0",
+				"@n8n/config": "2.24.1",
+				"@n8n/typescript-config": "1.5.0",
+				"@n8n/utils": "1.34.0",
+				"@thednp/dommatrix": "^2.0.12",
 				"https-proxy-agent": "7.0.6",
 				"js-tiktoken": "1.0.21",
 				"langchain": "1.2.30",
+				"pdf-parse": "2.4.5",
 				"proxy-from-env": "^1.1.0",
 				"tmp-promise": "3.0.3",
-				"undici": "^6.21.0",
+				"undici": "^6.24.0",
 				"zod": "3.25.67",
 				"zod-to-json-schema": "3.23.3"
 			},
@@ -2748,6 +1964,7 @@
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.27.tgz",
 			"integrity": "sha512-s2U3w7QV7QpkFtY1eZMni4poz+nKLFclpDi3a7hUbZ67ttsGaU9WkZ2BiLuzLIs+IFaUvON/KcGkE8EqAl9aPA==",
+			"deprecated": "This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3257,14 +2474,11 @@
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
-			"integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
+			"integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -3335,48 +2549,30 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"node_modules/@n8n/ai-utilities/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@n8n/config": {
-			"version": "2.19.1",
-			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.19.1.tgz",
-			"integrity": "sha512-4D3UV7ArTfN/G4GN5kCRHBD7ELplNN6rgySTbiv2XR0PrUpmYZBtkjSdDp0GafbQUu7h8CAB9qdnk8FUWx8krA==",
+			"version": "2.24.1",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.24.1.tgz",
+			"integrity": "sha512-qdLCqpLUqMvAYIf3JaMDgzYazkQYHLIWS7ToPIIYinf3Qa0PsFFceKMEZHP5DsggTA0gcRxrcDoJQhozA4ITTA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/di": "0.11.0",
+				"@n8n/constants": "0.26.0",
+				"@n8n/di": "0.13.0",
 				"reflect-metadata": "0.2.2",
 				"zod": "3.25.67"
 			}
 		},
+		"node_modules/@n8n/constants": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.26.0.tgz",
+			"integrity": "sha512-25BYGmGBD6zmbrbwJys0bHzmSiEth374kmzii3HC8jVfx0Lyms+vh1rzjAnvcvcY/zkJ8ic3fDvewvpzasb6AQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md"
+		},
 		"node_modules/@n8n/di": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.11.0.tgz",
-			"integrity": "sha512-6WHrIulFRD5KPAlVYQ1rPYzUKkbw856VEdzq03lmbOKUZpcuxr/wBSprUmbj//KCDsSK2lE0GZ/wSW03iV8YyQ==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.13.0.tgz",
+			"integrity": "sha512-pxsmn2UqcSnMQwb2zSSZcZZMViiOUnJVrRLoDZPhUZVbdAhmttQJGtm82+6hWPEc4wAOAMFbO1U3X53Wu29Y2g==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -3384,9 +2580,9 @@
 			}
 		},
 		"node_modules/@n8n/errors": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.7.0.tgz",
-			"integrity": "sha512-fz3VnXwiCk8B+u5vPg/49hz0b9X/RRMdaG+BgV9bozDMu390e2obAx9GPY75e3wht+p6i+6gt3C16eBabcXwNA==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.10.0.tgz",
+			"integrity": "sha512-Qle4gCsx7qtDRMdie3YkjuXPuo369PP32cR9Svb+INwcjLMxNzmnbJ66jFnOmLn0ntwBccUw1IecJ6axwyTgBQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
@@ -3394,49 +2590,52 @@
 			}
 		},
 		"node_modules/@n8n/eslint-plugin-community-nodes": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.15.0.tgz",
-			"integrity": "sha512-LSrySLyr2wgpbnOrykV9hlzK77+0f6H9uUg4tthsYXr1s8jDqGDUsfDhpw86M0SukZWFkuL8X8/1gLaGrypbBg==",
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.20.0.tgz",
+			"integrity": "sha512-5KCHQIWlL79H+YRkoG1UVMZ5OwHJ2i4m2/yYOMESTqPyLbgcRpiQBvnZHCbbSXUjImZ6vtSAPCzvSwYGW28pVQ==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
+				"@typescript-eslint/typescript-estree": "^8.35.0",
 				"@typescript-eslint/utils": "^8.35.0",
 				"fastest-levenshtein": "1.0.16"
 			},
 			"peerDependencies": {
-				"eslint": ">= 9",
+				"eslint": "9.29.0",
 				"n8n-workflow": ">=2"
 			}
 		},
 		"node_modules/@n8n/expression-runtime": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.10.1.tgz",
-			"integrity": "sha512-o9ppz7OUjeEaihkk2S8DG7NEb2NohpBAnp68UWDas9y5ockpE1050FuDNhhpOn0/e1S5fBo8Cf/uIzBmQj6rSg==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.18.1.tgz",
+			"integrity": "sha512-bZ4rSOHWs3CWI0KApS9SL+qR+ntXjw22uQdtSfVKq2uGpr8uwA55y3FlQhLBkskQNGGYLf7fW5tmH6LEy69iXA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "0.7.0",
-				"@n8n/tournament": "1.0.6",
-				"isolated-vm": "^6.0.2",
+				"@n8n/errors": "0.10.0",
+				"@n8n/tournament": "1.4.0",
+				"isolated-vm": "^6.1.2",
+				"jmespath": "0.16.0",
 				"js-base64": "3.7.8",
 				"jssha": "3.3.1",
 				"lodash": "4.18.1",
 				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"title-case": "3.0.3",
-				"transliteration": "2.3.5"
+				"transliteration": "2.3.5",
+				"zod": "3.25.67"
 			}
 		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.30.1.tgz",
-			"integrity": "sha512-upshbVjRQl/V3YRkoLeO/Y8giEcBOIPT7N2+U6jaftNGpVxTlHcPtZvMr1bPMQ0iDlSNUpOBB3tbWD4t4V/Tfg==",
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.35.1.tgz",
+			"integrity": "sha512-MhS7z3zJeUa+8YOztALZo7CGVAnhyS3kg+IiUYvxfwwKa6AOCicqK8IQyi2dkTeGPMSj66N9Ad0Fz5oG0QcVFQ==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/ai-node-sdk": "0.11.1",
-				"@n8n/eslint-plugin-community-nodes": "0.15.0",
+				"@n8n/ai-node-sdk": "0.16.1",
+				"@n8n/eslint-plugin-community-nodes": "0.20.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
 				"eslint-import-resolver-typescript": "^4.4.3",
@@ -3455,7 +2654,7 @@
 				"n8n-node": "bin/n8n-node.mjs"
 			},
 			"peerDependencies": {
-				"eslint": ">= 9"
+				"eslint": "9.29.0"
 			}
 		},
 		"node_modules/@n8n/node-cli/node_modules/prettier": {
@@ -3475,13 +2674,12 @@
 			}
 		},
 		"node_modules/@n8n/tournament": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.0.6.tgz",
-			"integrity": "sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==",
-			"license": "Apache-2.0",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.4.0.tgz",
+			"integrity": "sha512-llDdmIj3Kdfq2vX/NpLBOUU4kLjhITtIMeJmOSTApAOeAArj1D45ey4D7CFaYcYsPBw6DgF0vxifyskPDlgekw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
-				"@n8n_io/riot-tmpl": "^4.0.1",
 				"ast-types": "^0.16.1",
 				"esprima-next": "^5.8.4",
 				"recast": "^0.22.0"
@@ -3492,23 +2690,250 @@
 			}
 		},
 		"node_modules/@n8n/typescript-config": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.4.0.tgz",
-			"integrity": "sha512-HC2rgU/FtbOb6vpC/VvqfOxqeMkmQH/YdZK1y/wel7YgMCJcv92IhjJPehW1Qpp+OUesGTn03VJb4vee/ZEBkw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.5.0.tgz",
+			"integrity": "sha512-lRqZYmU0tRPAlVmUDfHBlgceE3GbQ5Zqkomrxs2wq5Kif8QqokJvB2T2xzYRrP3WGMDQbZqXeKs2E8Dm5t+nIw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md"
 		},
+		"node_modules/@n8n/utils": {
+			"version": "1.34.0",
+			"resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.34.0.tgz",
+			"integrity": "sha512-JOaQXZLIBBYN0rmXDd8VXK3OwXPMw1PdCXGSy+5xf6arPzm9+gkGRbrPcgh3vv4/sLbtfqyM7O5ohQK/axjMzQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/constants": "0.26.0",
+				"nanoid": "3.3.8"
+			}
+		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+			"integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"e2e/*"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "0.1.80",
+				"@napi-rs/canvas-darwin-arm64": "0.1.80",
+				"@napi-rs/canvas-darwin-x64": "0.1.80",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.80",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+			"integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+			"integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+			"integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+			"integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+			"integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+			"integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+			"integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+			"integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+			"integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+			"integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "^1.4.3",
-				"@emnapi/runtime": "^1.4.3",
-				"@tybys/wasm-util": "^0.10.0"
+				"@tybys/wasm-util": "^0.10.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -3550,9 +2975,9 @@
 			}
 		},
 		"node_modules/@oclif/core": {
-			"version": "4.10.5",
-			"resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.10.5.tgz",
-			"integrity": "sha512-qcdCF7NrdWPfme6Kr34wwljRCXbCVpL1WVxiNy0Ep6vbWKjxAjFQwuhqkoyL0yjI+KdwtLcOCGn5z2yzdijc8w==",
+			"version": "4.11.7",
+			"resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.7.tgz",
+			"integrity": "sha512-LHii7kSaLvv5bpbS09I7BlI1AQa3Kak/QDyyZOik79ET8tQyt1U5O38al+sYkMxi139105w5gS+aWe+5BlJ0yQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3567,10 +2992,10 @@
 				"is-wsl": "^2.2.0",
 				"lilconfig": "^3.1.3",
 				"minimatch": "^10.2.5",
-				"semver": "^7.7.3",
+				"semver": "^7.8.1",
 				"string-width": "^4.2.3",
 				"supports-color": "^8",
-				"tinyglobby": "^0.2.14",
+				"tinyglobby": "^0.2.16",
 				"widest-line": "^3.1.0",
 				"wordwrap": "^1.0.0",
 				"wrap-ansi": "^7.0.0"
@@ -3598,27 +3023,27 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+			"integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/pkgr"
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3645,9 +3070,9 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3660,6 +3085,17 @@
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@thednp/dommatrix": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@thednp/dommatrix/-/dommatrix-2.0.12.tgz",
+			"integrity": "sha512-eOshhlSShBXLfrMQqqhA450TppJXhKriaQdN43mmniOCMn9sD60QKF1Axsj7bKl339WH058LuGFS6H84njYH5w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20",
+				"pnpm": ">=8.6.0"
+			}
 		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
@@ -3700,42 +3136,10 @@
 				"tinyglobby": "^0.2.14"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -3800,9 +3204,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3860,13 +3264,13 @@
 			"peer": true
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": "~5.26.4"
 			}
 		},
 		"node_modules/@types/node-fetch": {
@@ -3921,17 +3325,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-			"integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+			"integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.0",
-				"@typescript-eslint/type-utils": "8.59.0",
-				"@typescript-eslint/utils": "8.59.0",
-				"@typescript-eslint/visitor-keys": "8.59.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/type-utils": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -3944,7 +3348,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.0",
+				"@typescript-eslint/parser": "^8.61.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -3960,16 +3364,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-			"integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.0",
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/typescript-estree": "8.59.0",
-				"@typescript-eslint/visitor-keys": "8.59.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3985,14 +3389,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-			"integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+			"integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.0",
-				"@typescript-eslint/types": "^8.59.0",
+				"@typescript-eslint/tsconfig-utils": "^8.61.1",
+				"@typescript-eslint/types": "^8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -4007,14 +3411,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-			"integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/visitor-keys": "8.59.0"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4025,9 +3429,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-			"integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+			"integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4042,15 +3446,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-			"integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+			"integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/typescript-estree": "8.59.0",
-				"@typescript-eslint/utils": "8.59.0",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -4067,9 +3471,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-			"integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4081,16 +3485,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-			"integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+			"integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.0",
-				"@typescript-eslint/tsconfig-utils": "8.59.0",
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/visitor-keys": "8.59.0",
+				"@typescript-eslint/project-service": "8.61.1",
+				"@typescript-eslint/tsconfig-utils": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -4109,16 +3513,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-			"integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+			"integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.0",
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/typescript-estree": "8.59.0"
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4133,13 +3537,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-			"integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.0",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -4164,16 +3568,16 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+			"integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
 			"cpu": [
 				"arm"
 			],
@@ -4185,9 +3589,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-android-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+			"integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4199,9 +3603,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-darwin-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+			"integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -4213,9 +3617,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-darwin-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+			"integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
 			"cpu": [
 				"x64"
 			],
@@ -4227,9 +3631,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-freebsd-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+			"integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
 			"cpu": [
 				"x64"
 			],
@@ -4241,9 +3645,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+			"integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
 			"cpu": [
 				"arm"
 			],
@@ -4255,9 +3659,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+			"integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
 			"cpu": [
 				"arm"
 			],
@@ -4269,13 +3673,16 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+			"integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4283,13 +3690,50 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+			"integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+			"integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+			"integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4297,13 +3741,16 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+			"integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4311,13 +3758,16 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+			"integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4325,13 +3775,16 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+			"integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4339,13 +3792,16 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+			"integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4353,13 +3809,16 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+			"integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4367,23 +3826,40 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+			"integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
+		"node_modules/@unrs/resolver-binding-openharmony-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+			"integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
 		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+			"integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
 			"cpu": [
 				"wasm32"
 			],
@@ -4391,16 +3867,18 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@napi-rs/wasm-runtime": "^0.2.11"
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+			"integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
 			"cpu": [
 				"arm64"
 			],
@@ -4412,9 +3890,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+			"integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
 			"cpu": [
 				"ia32"
 			],
@@ -4426,9 +3904,9 @@
 			]
 		},
 		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+			"integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
 			"cpu": [
 				"x64"
 			],
@@ -4454,9 +3932,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -4474,20 +3952,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/acorn-walk": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"acorn": "^8.11.0"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -4561,15 +4025,13 @@
 			}
 		},
 		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -4599,13 +4061,18 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -4682,9 +4149,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-			"integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+			"integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -4707,24 +4174,6 @@
 			},
 			"engines": {
 				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/axios/node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/axios/node_modules/https-proxy-agent": {
@@ -4754,16 +4203,16 @@
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-			"integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "30.2.0",
+				"@jest/transform": "30.4.1",
 				"@types/babel__core": "^7.20.5",
 				"babel-plugin-istanbul": "^7.0.1",
-				"babel-preset-jest": "30.2.0",
+				"babel-preset-jest": "30.4.0",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
@@ -4796,9 +4245,9 @@
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-			"integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4836,13 +4285,13 @@
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-			"integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "30.2.0",
+				"babel-plugin-jest-hoist": "30.4.0",
 				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
@@ -4884,9 +4333,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.21",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-			"integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+			"version": "2.10.38",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+			"integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -5078,19 +4527,22 @@
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001790",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-			"integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5123,6 +4575,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/chalk/node_modules/supports-color": {
@@ -5309,9 +4777,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
-			"integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+			"integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5331,14 +4799,6 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -5481,17 +4941,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/diff": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -5583,9 +5032,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.344",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-			"integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+			"version": "1.5.376",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+			"integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5639,9 +5088,9 @@
 			}
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -5690,24 +5139,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+			"version": "9.29.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+			"integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.1",
-				"@eslint/config-helpers": "^0.4.2",
-				"@eslint/core": "^0.17.0",
+				"@eslint/config-array": "^0.20.1",
+				"@eslint/config-helpers": "^0.2.1",
+				"@eslint/core": "^0.14.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.2",
-				"@eslint/plugin-kit": "^0.4.1",
+				"@eslint/js": "9.29.0",
+				"@eslint/plugin-kit": "^0.3.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
+				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
@@ -5749,13 +5199,6 @@
 				}
 			}
 		},
-		"node_modules/eslint-config-riot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
-			"integrity": "sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/eslint-import-context": {
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -5782,9 +5225,9 @@
 			}
 		},
 		"node_modules/eslint-import-resolver-typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
-			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+			"integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5901,9 +5344,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6061,9 +5504,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6147,9 +5590,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6245,9 +5688,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6400,9 +5843,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6600,18 +6043,18 @@
 			}
 		},
 		"node_modules/expect": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-			"integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/expect-utils": "30.3.0",
+				"@jest/expect-utils": "30.4.1",
 				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-mock": "30.3.0",
-				"jest-util": "30.3.0"
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6706,6 +6149,24 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6757,9 +6218,9 @@
 			"license": "MIT"
 		},
 		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6896,17 +6357,18 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -7114,9 +6576,9 @@
 			"license": "MIT"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7276,9 +6738,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -7331,9 +6793,9 @@
 			}
 		},
 		"node_modules/ibm-cloud-sdk-core": {
-			"version": "5.4.20",
-			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.20.tgz",
-			"integrity": "sha512-3jdfmJvV67DOlzHfNgLFkRgitmly/qlq/MBqfVuFEugNe4zrYQar8IRIfby635ZpbKR4PmdmRjIjn5f0kQy2Ig==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.5.0.tgz",
+			"integrity": "sha512-ot6sGHAvSnd/ZSU4ZFn+m7i+xcFo3pmA3qm2JmEndDkMsuNR8HLdUeJ5iBbmkUfCGbf2ccTu/GvoJgFetyO6XA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -7341,13 +6803,13 @@
 				"@types/debug": "4.1.12",
 				"@types/node": "18.19.80",
 				"@types/tough-cookie": "4.0.0",
-				"axios": "1.16.1",
+				"axios": "1.18.0",
 				"camelcase": "6.3.0",
 				"debug": "4.3.4",
 				"dotenv": "16.4.5",
 				"extend": "3.0.2",
 				"file-type": "21.3.2",
-				"form-data": "4.0.4",
+				"form-data": "4.0.6",
 				"isstream": "0.1.2",
 				"jsonwebtoken": "9.0.3",
 				"load-esm": "1.0.3",
@@ -7368,20 +6830,6 @@
 			"peer": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/ibm-cloud-sdk-core/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ibm-cloud-sdk-core/node_modules/debug": {
@@ -7421,14 +6869,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/ibm-cloud-sdk-core/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -7949,16 +7389,16 @@
 			"license": "ISC"
 		},
 		"node_modules/jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
-			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
 				"import-local": "^3.2.0",
-				"jest-cli": "30.2.0"
+				"jest-cli": "30.4.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -7976,75 +7416,44 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
-			"integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"execa": "^5.1.1",
-				"jest-util": "30.2.0",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-changed-files/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-changed-files/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-circus": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
-			"integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/expect": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"co": "^4.6.0",
 				"dedent": "^1.6.0",
 				"is-generator-fn": "^2.1.0",
-				"jest-each": "30.2.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0",
-				"pretty-format": "30.2.0",
+				"pretty-format": "30.4.1",
 				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
@@ -8053,144 +7462,22 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-circus/node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-circus/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-cli": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
-			"integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"chalk": "^4.1.2",
 				"exit-x": "^0.2.2",
 				"import-local": "^3.2.0",
-				"jest-config": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -8208,66 +7495,34 @@
 				}
 			}
 		},
-		"node_modules/jest-cli/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-config": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
-			"integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
 				"@jest/get-type": "30.1.0",
-				"@jest/pattern": "30.0.1",
-				"@jest/test-sequencer": "30.2.0",
-				"@jest/types": "30.2.0",
-				"babel-jest": "30.2.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"deepmerge": "^4.3.1",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.2.0",
-				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-runner": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"parse-json": "^5.2.0",
-				"pretty-format": "30.2.0",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -8291,85 +7546,26 @@
 				}
 			}
 		},
-		"node_modules/jest-config/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-config/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-config/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-config/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-diff": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/diff-sequences": "30.3.0",
+				"@jest/diff-sequences": "30.4.0",
 				"@jest/get-type": "30.1.0",
 				"chalk": "^4.1.2",
-				"pretty-format": "30.3.0"
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8380,162 +7576,57 @@
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
-			"integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"chalk": "^4.1.2",
-				"jest-util": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-each/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-each/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
-			"integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0"
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-			"integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"anymatch": "^3.1.3",
 				"fb-watchman": "^2.0.2",
 				"graceful-fs": "^4.2.11",
-				"jest-regex-util": "30.0.1",
-				"jest-util": "30.2.0",
-				"jest-worker": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
 				"walker": "^1.0.8"
 			},
 			"engines": {
@@ -8545,109 +7636,51 @@
 				"fsevents": "^2.3.3"
 			}
 		},
-		"node_modules/jest-haste-map/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-leak-detector": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
-			"integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-leak-detector/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-leak-detector/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-			"integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
 				"chalk": "^4.1.2",
-				"jest-diff": "30.3.0",
-				"pretty-format": "30.3.0"
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.3.0",
+				"@jest/types": "30.4.1",
 				"@types/stack-utils": "^2.0.3",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
 				"picomatch": "^4.0.3",
-				"pretty-format": "30.3.0",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
 			},
@@ -8655,67 +7688,16 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-message-util/node_modules/@jest/types": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.5",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-mock": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.3.0",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-util": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@jest/types": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.5",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
+				"jest-util": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8740,9 +7722,9 @@
 			}
 		},
 		"node_modules/jest-regex-util": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8750,18 +7732,18 @@
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
-			"integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.4.1",
 				"jest-pnp-resolver": "^1.2.3",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"slash": "^3.0.0",
 				"unrs-resolver": "^1.7.11"
 			},
@@ -8770,77 +7752,46 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
-			"integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-regex-util": "30.0.1",
-				"jest-snapshot": "30.2.0"
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-resolve/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-resolve/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
-			"integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/environment": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
-				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.2.0",
-				"jest-haste-map": "30.2.0",
-				"jest-leak-detector": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-resolve": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-watcher": "30.2.0",
-				"jest-worker": "30.2.0",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
@@ -8848,113 +7799,33 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runner/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-runner/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-runner/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-runtime": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
-			"integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/globals": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
 				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"cjs-module-lexer": "^2.1.0",
 				"collect-v8-coverage": "^1.0.2",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
@@ -8962,105 +7833,10 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runtime/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-snapshot": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
-			"integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9069,20 +7845,20 @@
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1",
 				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.2.0",
+				"@jest/expect-utils": "30.4.1",
 				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/snapshot-utils": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"babel-preset-current-node-syntax": "^1.2.0",
 				"chalk": "^4.1.2",
-				"expect": "30.2.0",
+				"expect": "30.4.1",
 				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.2.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
-				"pretty-format": "30.2.0",
+				"jest-diff": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1",
 				"semver": "^7.7.2",
 				"synckit": "^0.11.8"
 			},
@@ -9090,182 +7866,14 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-snapshot/node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/@jest/expect-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "30.2.0",
-				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-util": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.3.0",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
@@ -9276,194 +7884,59 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-util/node_modules/@jest/types": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.5",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-validate": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
-			"integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"camelcase": "^6.3.0",
 				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-validate/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-validate/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/jest-validate/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
-			"integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "30.2.0",
+				"jest-util": "30.4.1",
 				"string-length": "^4.0.2"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-watcher/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-watcher/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-worker": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-			"integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"@ungap/structured-clone": "^1.3.0",
-				"jest-util": "30.2.0",
+				"jest-util": "30.4.1",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.1.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jmespath": {
@@ -9501,10 +7974,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -9711,9 +8194,9 @@
 			}
 		},
 		"node_modules/langsmith": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.2.tgz",
-			"integrity": "sha512-OrFt+a2P4UMaa2cSpp3fjYTJ+TWQFjnoz5j4njiZYWMpAJezTrMRN1mrNVzq/FACprgPwAMjq5YkZNRYJKorwg==",
+			"version": "0.7.10",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.10.tgz",
+			"integrity": "sha512-3EjJx9zGMzqF60eT9JADHF+Hn/T5ayTgEVp4d3M5yvJIJi3q6seX0p5jT8ecBCWBi1kIvvssWrcDxfwgSier7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10025,6 +8508,19 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -10112,15 +8608,15 @@
 			}
 		},
 		"node_modules/n8n-workflow": {
-			"version": "2.18.2",
-			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.18.2.tgz",
-			"integrity": "sha512-rI+uew2XiUOg8UdVlggrYwugG9w6VWdTVjxdodwU0gVL2Vi1GABhvHXHJValXTRrjjCjtkWbWSGqquss2REpew==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.27.1.tgz",
+			"integrity": "sha512-3kNIcWWeJ3bNLl6jtIcyjBcbdCAfme3kC6VaNnKvrYUWCyG2vN0WvfCIMTAx9sDZitOJAAVhbFLx3DvmsZKM1A==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "0.7.0",
-				"@n8n/expression-runtime": "0.10.1",
-				"@n8n/tournament": "1.0.6",
+				"@n8n/errors": "0.10.0",
+				"@n8n/expression-runtime": "0.18.1",
+				"@n8n/tournament": "1.4.0",
 				"ast-types": "0.16.1",
 				"callsites": "3.1.0",
 				"esprima-next": "5.8.4",
@@ -10135,11 +8631,61 @@
 				"recast": "0.22.0",
 				"title-case": "3.0.3",
 				"transliteration": "2.3.5",
-				"uuid": "10.0.0",
+				"uuid": "11.1.1",
 				"xml2js": "0.6.2"
 			},
 			"peerDependencies": {
 				"zod": "3.25.67"
+			}
+		},
+		"node_modules/n8n-workflow/node_modules/form-data": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/n8n-workflow/node_modules/uuid": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
 		"node_modules/napi-postinstall": {
@@ -10247,11 +8793,14 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.38",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+			"version": "2.0.48",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+			"integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -10381,25 +8930,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/openai/node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/openai/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/openapi-types": {
 			"version": "12.1.3",
@@ -10645,6 +9175,40 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pdf-parse": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+			"integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@napi-rs/canvas": "0.1.80",
+				"pdfjs-dist": "5.4.296"
+			},
+			"bin": {
+				"pdf-parse": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": ">=20.16.0 <21 || >=22.3.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/mehmet-kozan"
+			}
+		},
+		"node_modules/pdfjs-dist": {
+			"version": "5.4.296",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+			"integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=20.16.0 || >=22.3.0"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas": "^0.1.80"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -10653,13 +9217,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -10745,14 +9309,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -10765,9 +9329,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -10825,9 +9389,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -10841,31 +9405,19 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "30.0.5",
+				"@jest/schemas": "30.4.1",
 				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/pretty-format/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/prompts": {
@@ -10959,10 +9511,19 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/react-is": {
+		"node_modules/react-is-18": {
+			"name": "react-is",
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/react-is-19": {
+			"name": "react-is",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+			"integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11160,9 +9721,9 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/lru-cache": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -11261,9 +9822,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -11635,13 +10196,13 @@
 			}
 		},
 		"node_modules/synckit": {
-			"version": "0.11.12",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+			"integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.9"
+				"@pkgr/core": "^0.3.6"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -11673,9 +10234,9 @@
 			"license": "MIT"
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11727,9 +10288,9 @@
 			"peer": true
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11741,37 +10302,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/title-case": {
@@ -11899,19 +10429,19 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.6",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-			"integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+			"version": "29.4.11",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+			"integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
 				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.8",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.3",
+				"semver": "^7.8.0",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -11928,7 +10458,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <6"
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -11975,51 +10505,6 @@
 				"code-block-writer": "^13.0.3"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -12063,9 +10548,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -12077,16 +10562,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
-			"integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+			"integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.0",
-				"@typescript-eslint/parser": "8.59.0",
-				"@typescript-eslint/typescript-estree": "8.59.0",
-				"@typescript-eslint/utils": "8.59.0"
+				"@typescript-eslint/eslint-plugin": "8.61.1",
+				"@typescript-eslint/parser": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12129,9 +10614,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-			"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12139,9 +10624,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12157,38 +10642,41 @@
 			}
 		},
 		"node_modules/unrs-resolver": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+			"integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"napi-postinstall": "^0.3.0"
+				"napi-postinstall": "^0.3.4"
 			},
 			"funding": {
 				"url": "https://opencollective.com/unrs-resolver"
 			},
 			"optionalDependencies": {
-				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-				"@unrs/resolver-binding-android-arm64": "1.11.1",
-				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
-				"@unrs/resolver-binding-darwin-x64": "1.11.1",
-				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
-				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+				"@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+				"@unrs/resolver-binding-android-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-x64": "1.12.2",
+				"@unrs/resolver-binding-freebsd-x64": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+				"@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+				"@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -12279,6 +10767,8 @@
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
 			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -12287,14 +10777,6 @@
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
-		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.3.0",
@@ -12369,14 +10851,14 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
+				"call-bind": "^1.0.9",
 				"call-bound": "^1.0.4",
 				"for-each": "^0.3.5",
 				"get-proto": "^1.0.1",
@@ -12466,6 +10948,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -12486,6 +10984,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
@@ -12585,9 +11098,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -12601,9 +11114,9 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -12625,17 +11138,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
 		"@n8n/node-cli": "0.35.1",
 		"@types/jest": "30.0.0",
 		"eslint": "9.29.0",
-		"jest": "30.4.2",
+		"jest": "30.2.0",
 		"prettier": "3.8.4",
-		"ts-jest": "29.4.11",
-		"typescript": "6.0.3"
+		"ts-jest": "29.4.6",
+		"typescript": "5.9.3"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
 	"toonSpecVersion": "3.3.0",
 	"license": "MIT",
@@ -46,13 +46,13 @@
 		]
 	},
 	"devDependencies": {
-		"@n8n/node-cli": "^0.30.1",
+		"@n8n/node-cli": "0.35.1",
 		"@types/jest": "30.0.0",
-		"eslint": "9.39.2",
-		"jest": "30.2.0",
-		"prettier": "3.8.1",
-		"ts-jest": "29.4.6",
-		"typescript": "5.9.3"
+		"eslint": "9.29.0",
+		"jest": "30.4.2",
+		"prettier": "3.8.4",
+		"ts-jest": "29.4.11",
+		"typescript": "6.0.3"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"


### PR DESCRIPTION
* Bump version to `1.3.2`
* Update `@n8n/node-cli` from `^0.30.1` to `0.35.1`
* Downgrade `eslint` from `9.39.2` to `9.29.0`
* Update `jest` from `30.2.0` to `30.4.2`
* Update `prettier` from `3.8.1` to `3.8.4`
* Update `ts-jest` from `29.4.6` to `29.4.11`
* Update `typescript` from `5.9.3` to `6.0.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to **1.3.2**
  * Updated development tooling dependencies (linting, formatting, and TypeScript tooling) for improved development experience and code quality
  * Tightened security scanning in CI by raising the npm audit severity threshold from **high** to **critical** for more stringent vulnerability detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->