### PR TITLE
fix(ci): pin action SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/monitor-spec.yml
+++ b/.github/workflows/monitor-spec.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Fetch current local spec version
         id: local-version
@@ -104,7 +104,7 @@ jobs:
 
       - name: Create issue for spec update
         if: steps.compare.outputs.changes_detected == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           LOCAL_VERSION: ${{ steps.local-version.outputs.version }}
           UPSTREAM_VERSION: ${{ steps.upstream-version.outputs.version }}

--- a/.github/workflows/monitor-spec.yml
+++ b/.github/workflows/monitor-spec.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Fetch current local spec version
         id: local-version

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download latest dist artifacts from CI
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: ci.yml
           name: dist
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload artifacts for scanning
         if: hashFiles('dist/**/*') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: dist/


### PR DESCRIPTION
## Summary
- Pins `dawidd6/action-download-artifact@v6`, `actions/upload-artifact@v4`, `actions/checkout@v4`, and `actions/github-script@v7` to full commit SHAs across `security-scan.yml` and `monitor-spec.yml`, resolving `github-actions-mutable-action-tag`.
- No code change needed for the open `prototype-pollution-loop` alerts on `ToonEncoder.ts:378,410` and `ToonDecoder.ts:790`: already suppressed with documented `nosemgrep` justifications, guarded by `isSafeKey()` blocking `__proto__`/`constructor`/`prototype` (commit `8c4bc8b`, which postdates the alerts' creation timestamps). These are stale GitHub code-scanning alerts that should auto-close on the next scan.

## Test plan
- [x] `npm run lint && npm run test && npm run build` passes locally (211 tests)
- [ ] CI passes
- [ ] Confirm the 3 stale alerts auto-close after next Semgrep scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned automation workflow steps to immutable commit SHAs for more consistent and reliable runs.
* **Bug Fixes**
  * Improved workflow stability by reducing the risk of unexpected changes from upstream GitHub Action updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->