### PR TITLE
chore: track TOON spec 3.3.2, update dev deps, fix spec monitor false alarms

### DIFF
--- a/.github/workflows/monitor-spec.yml
+++ b/.github/workflows/monitor-spec.yml
@@ -9,15 +9,20 @@
 # Workflow Steps:
 # 1. Fetch local SPEC.md version/date
 # 2. Fetch upstream SPEC.md from https://github.com/toon-format/spec
-# 3. Compare versions and dates
+# 3. Compare versions, then compare SPEC.md content
 # 4. If changes detected:
-#    - Generate diff summary
+#    - Generate diff summary (only when the content actually differs)
 #    - Create GitHub issue (or update existing)
 #    - Label with 'spec-update' and 'enhancement'
 #    - Avoid duplicate issues for same version
 #
+# The spec repo versions independently of its content, so a release may ship a
+# byte-identical SPEC.md (tooling-only changes). Those produce a tracking-only
+# issue instead of a false "update the implementation" alarm.
+#
 # Issue Format:
-# - Title: "TOON Specification Update Available: vX.Y"
+# - Title: "TOON Specification Update Available: vX.Y" (content changed), or
+#          "TOON Spec Version Bump (no content change): vX.Y"
 # - Body: Version comparison, diff, action checklist, links
 # - Labels: spec-update, enhancement
 #
@@ -79,16 +84,28 @@ jobs:
           echo "  Local: ${LOCAL_VERSION}"
           echo "  Upstream: ${UPSTREAM_VERSION} (released ${UPSTREAM_DATE})"
 
-          if [ "${LOCAL_VERSION}" != "${UPSTREAM_VERSION}" ]; then
-            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected!"
-          else
+          if [ "${LOCAL_VERSION}" = "${UPSTREAM_VERSION}" ]; then
             echo "changes_detected=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected"
+            exit 0
+          fi
+
+          echo "changes_detected=true" >> "$GITHUB_OUTPUT"
+
+          # The spec repo versions independently of its content: tooling-only
+          # releases (dependency bumps, CI changes) ship a byte-identical
+          # SPEC.md. Distinguish those from real normative changes so the issue
+          # can state which kind of update this is.
+          if cmp -s SPEC.md /tmp/upstream-spec.md; then
+            echo "spec_changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version bump only - SPEC.md is byte-identical upstream"
+          else
+            echo "spec_changed=true" >> "$GITHUB_OUTPUT"
+            echo "SPEC.md content changed upstream"
           fi
 
       - name: Generate diff summary
-        if: steps.compare.outputs.changes_detected == 'true'
+        if: steps.compare.outputs.spec_changed == 'true'
         id: diff
         run: |
           # Generate a summary of changes
@@ -111,47 +128,80 @@ jobs:
           LOCAL_VERSION: ${{ steps.local-version.outputs.version }}
           UPSTREAM_VERSION: ${{ steps.upstream-version.outputs.version }}
           UPSTREAM_DATE: ${{ steps.upstream-version.outputs.date }}
+          SPEC_CHANGED: ${{ steps.compare.outputs.spec_changed }}
           SPEC_DIFF: ${{ steps.diff.outputs.diff }}
         with:
           script: |
             const localVersion = process.env.LOCAL_VERSION;
             const upstreamVersion = process.env.UPSTREAM_VERSION;
             const upstreamDate = process.env.UPSTREAM_DATE;
+            const specChanged = process.env.SPEC_CHANGED === 'true';
             const diff = process.env.SPEC_DIFF;
 
-            const issueTitle = `TOON Specification Update Available: v${upstreamVersion}`;
+            const issueTitle = specChanged
+              ? `TOON Specification Update Available: v${upstreamVersion}`
+              : `TOON Spec Version Bump (no content change): v${upstreamVersion}`;
+
+            const heading = specChanged
+              ? '## 🔔 TOON Specification Update Detected'
+              : '## 📦 TOON Spec Version Bump (no content change)';
+
+            const intro = specChanged
+              ? 'A new version of the TOON specification is available from the official repository.'
+              : [
+                  'A new version of the TOON specification was released, but `SPEC.md` is',
+                  '**byte-for-byte identical** to the copy in this repository. The spec repo',
+                  'versions independently of its content, so this release only changed repo',
+                  'tooling (dependencies, CI). **No implementation changes are required.**'
+                ].join('\n');
+
+            const actionSection = specChanged
+              ? [
+                  '### Action Required',
+                  '',
+                  'Please review the changes in the official specification and update our implementation accordingly:',
+                  '',
+                  '1. Review the upstream specification: https://github.com/toon-format/spec/blob/main/SPEC.md',
+                  '2. Update `SPEC.md` to match the latest version',
+                  '3. Review and update implementation in `nodes/Toon/` if needed',
+                  '4. Update tests to cover any new features or changes',
+                  '5. Update `README.md` to reflect the new version',
+                  '6. Update `package.json` if appropriate',
+                  '',
+                  '### Diff Summary (first 100 lines)',
+                  '',
+                  '<details>',
+                  '<summary>Click to expand diff</summary>',
+                  '',
+                  '```diff',
+                  diff,
+                  '```',
+                  '',
+                  '</details>'
+                ]
+              : [
+                  '### Action Required',
+                  '',
+                  'Tracking-only update:',
+                  '',
+                  '1. Bump `toonSpecVersion` in `package.json` to `' + upstreamVersion + '`',
+                  '2. Bump our own package version (patch only)',
+                  '',
+                  '`SPEC.md`, `nodes/Toon/`, and the tests do not need to change.'
+                ];
 
             const issueBody = [
-              '## 🔔 TOON Specification Update Detected',
+              heading,
               '',
-              'A new version of the TOON specification is available from the official repository.',
+              intro,
               '',
               '### Version Information',
               '',
               `- **Current (Local):** v${localVersion}`,
               `- **Latest (Upstream):** v${upstreamVersion} (${upstreamDate})`,
+              `- **SPEC.md content changed:** ${specChanged ? 'yes' : 'no (identical)'}`,
               '',
-              '### Action Required',
-              '',
-              'Please review the changes in the official specification and update our implementation accordingly:',
-              '',
-              '1. Review the upstream specification: https://github.com/toon-format/spec/blob/main/SPEC.md',
-              '2. Update `SPEC.md` to match the latest version',
-              '3. Review and update implementation in `nodes/Toon/` if needed',
-              '4. Update tests to cover any new features or changes',
-              '5. Update `README.md` to reflect the new version',
-              '6. Update `package.json` if appropriate',
-              '',
-              '### Diff Summary (first 100 lines)',
-              '',
-              '<details>',
-              '<summary>Click to expand diff</summary>',
-              '',
-              '```diff',
-              diff,
-              '```',
-              '',
-              '</details>',
+              ...actionSection,
               '',
               '### Useful Links',
               '',

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is an n8n community node for bidirectional conversion between TOON (Token-Oriented Object Notation) and JSON formats. The implementation follows the **TOON Specification v3.0.3** (see `SPEC.md`) with **zero external production dependencies**.
+This is an n8n community node for bidirectional conversion between TOON (Token-Oriented Object Notation) and JSON formats. The implementation follows the **TOON Specification v3.3** (see `SPEC.md`) with **zero external production dependencies**.
 
 ## Development Setup
 
@@ -81,7 +81,10 @@ nodes/Toon/
 
 ## TOON Specification Compliance
 
-Spec version: **3.0.3** — tracked in `package.json` field `toonSpecVersion`.
+Spec version: **3.3.2** — tracked in `package.json` field `toonSpecVersion`.
+
+Version annotations like *(v3.0.3)* in the table below mark the release that
+introduced a given rule; they are historical and intentionally not updated.
 
 | Spec Section | Feature | Implementation | Status |
 |---|---|---|---|
@@ -183,6 +186,27 @@ An automated GitHub Actions workflow monitors the official TOON specification fo
 - Opens a GitHub issue if changes are detected (with diff summary)
 - Prevents duplicate issues for the same version
 - Adds reminder comments to existing open issues
+
+**Spec versioning nuance:**
+
+The specification lives in its own repository (`toon-format/spec`), separate
+from the reference implementation (`toon-format/toon`). It versions
+independently of its content, so a new release does **not** imply the spec text
+changed — v3.3.0, v3.3.1, and v3.3.2 all ship a byte-identical `SPEC.md`, with
+only repo tooling changing between them.
+
+The workflow therefore compares content as well as version numbers, and labels
+the issue accordingly:
+
+- **Content changed** → "TOON Specification Update Available", full review
+  checklist plus diff.
+- **Content identical** → "TOON Spec Version Bump (no content change)". Only
+  bump `toonSpecVersion` in `package.json` and take a patch bump on our own
+  version; `SPEC.md`, `nodes/Toon/`, and the tests stay untouched.
+
+Note that `toonSpecVersion` tracks the spec repo, which is a different version
+line from the `@toon-format/toon` reference implementation — do not conflate
+the two.
 
 **Manual Trigger:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -318,11 +318,11 @@ Workflow: Fetch Data → JSON to TOON → Format Report → Send Email
 
 - **n8n version:** 0.200.0 or later
 - **Node.js:** 18.x or later
-- **TOON Specification:** v3.0
+- **TOON Specification:** v3.3
 
 ## Specification Compliance
 
-This node implements **TOON Specification v3.0** with comprehensive coverage of all core features and major optional features.
+This node implements **TOON Specification v3.3** with comprehensive coverage of all core features and major optional features.
 
 ### Implemented Features
 
@@ -463,7 +463,7 @@ See [`.github/workflows/security-scan.yml`](.github/workflows/security-scan.yml)
 
 ## Resources
 
-- **TOON Specification v3.0:** Official spec at [github.com/toon-format/spec](https://github.com/toon-format/spec) or see [SPEC.md](SPEC.md) in this repository
+- **TOON Specification v3.3:** Official spec at [github.com/toon-format/spec](https://github.com/toon-format/spec) or see [SPEC.md](SPEC.md) in this repository
 - **n8n Documentation:** https://docs.n8n.io/
 - **Community Nodes Guide:** https://docs.n8n.io/integrations/community-nodes/
 - **GitHub Repository:** https://github.com/tehw0lf/n8n-nodes-toon
@@ -483,4 +483,4 @@ Contributions are welcome! Please open an issue or pull request on GitHub.
 
 ---
 
-**Note:** This node implements the [TOON Specification v3.0](https://github.com/toon-format/spec). See `SPEC.md` for complete format documentation or visit the official spec repository.
+**Note:** This node implements the [TOON Specification v3.3](https://github.com/toon-format/spec). See `SPEC.md` for complete format documentation or visit the official spec repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tehw0lf/n8n-nodes-toon",
-			"version": "1.3.2",
+			"version": "1.3.3",
 			"license": "MIT",
 			"devDependencies": {
-				"@n8n/node-cli": "0.35.1",
+				"@n8n/node-cli": "0.40.2",
 				"@types/jest": "30.0.0",
 				"eslint": "9.29.0",
-				"jest": "30.2.0",
-				"prettier": "3.8.4",
-				"ts-jest": "29.4.6",
+				"jest": "30.4.2",
+				"prettier": "3.9.6",
+				"ts-jest": "29.4.11",
 				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
@@ -36,6 +36,49 @@
 				"form-data-encoder": "1.7.2",
 				"formdata-node": "^4.3.2",
 				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@apm-js-collab/code-transformer": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz",
+			"integrity": "sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/estree": "^1.0.8",
+				"astring": "^1.9.0",
+				"esquery": "^1.7.0",
+				"meriyah": "^6.1.4",
+				"semifies": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"bin": {
+				"code-transformer": "cli.js"
+			}
+		},
+		"node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.2.tgz",
+			"integrity": "sha512-GvpKWDmzBFzbtVElU+tEDMDYyMY8SnMH4NNwwlUQioNHZvE6sSuHEqNkfU3iYhWL+/XO5Ej+MzhVJoqM10NYCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@apm-js-collab/code-transformer": "^0.18.0",
+				"es-module-lexer": "^2.1.0",
+				"magic-string": "^0.30.21",
+				"module-details-from-path": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@apm-js-collab/tracing-hooks": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+			"integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@apm-js-collab/code-transformer": "^0.18.0",
+				"debug": "^4.4.1",
+				"module-details-from-path": "^1.0.4"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -574,10 +617,11 @@
 			}
 		},
 		"node_modules/@browserbasehq/sdk": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.14.1.tgz",
-			"integrity": "sha512-Ahmzb5+82ePgSGwouKEoAhiGy8mJ3RbCl+uigfGfVc60zseYIftcMiDPXSmrTQr1NHaATRx4cJlynP8ZUweXtg==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.16.0.tgz",
+			"integrity": "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@types/node": "^18.11.18",
@@ -649,6 +693,75 @@
 				"@clack/core": "0.5.0",
 				"picocolors": "^1.0.0",
 				"sisteransi": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/autocomplete": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.17.0",
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.12.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+			"integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.5.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+			"integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.43.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+			"integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.7.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+			"integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@so-ric/colorspace": "^1.1.6",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -926,57 +1039,6 @@
 				"node": ">=18.18.0"
 			}
 		},
-		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-			"deprecated": "Use @eslint/config-array instead",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.3",
-				"debug": "^4.3.1",
-				"minimatch": "^3.0.5"
-			},
-			"engines": {
-				"node": ">=10.10.0"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -990,15 +1052,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
 			}
-		},
-		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-			"deprecated": "Use @eslint/object-schema instead",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
 		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
@@ -1015,9 +1068,9 @@
 			}
 		},
 		"node_modules/@ibm-cloud/watsonx-ai": {
-			"version": "1.7.14",
-			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.14.tgz",
-			"integrity": "sha512-nP0ayzuck6gDpL5ohkI7t3ExXPfF0TICyO/QroGbW7lKd996Rzzls1+X9gZE3B6xQLbCJz9/AsM+YhE+dcnY5g==",
+			"version": "1.7.15",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.15.tgz",
+			"integrity": "sha512-JUxFuACcKhDC+shavgyLEFjWiSsBjI+tjIBvLrzcHywh0HqTT0m+whe2kL3isPheBzrduSMfovwypbSuKwCp+g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -1231,124 +1284,57 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
-			"integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/console/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/console/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/core": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
-			"integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/pattern": "30.0.1",
-				"@jest/reporters": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-changed-files": "30.2.0",
-				"jest-config": "30.2.0",
-				"jest-haste-map": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-resolve-dependencies": "30.2.0",
-				"jest-runner": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
-				"jest-watcher": "30.2.0",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1363,73 +1349,6 @@
 				}
 			}
 		},
-		"node_modules/@jest/core/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/core/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/core/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/core/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/diff-sequences": {
 			"version": "30.4.0",
 			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
@@ -1441,76 +1360,30 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "30.2.0"
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@jest/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "30.2.0",
-				"jest-snapshot": "30.2.0"
+				"expect": "30.4.1",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1529,256 +1402,19 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/expect/node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/@jest/expect-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "30.2.0",
-				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/fake-timers": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@sinonjs/fake-timers": "^13.0.0",
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
 				"@types/node": "*",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1795,108 +1431,62 @@
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-			"integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/expect": "30.2.0",
-				"@jest/types": "30.2.0",
-				"jest-mock": "30.2.0"
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/types": "30.4.1",
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@jest/pattern": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
-				"jest-regex-util": "30.0.1"
+				"jest-regex-util": "30.4.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
-			"integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"collect-v8-coverage": "^1.0.2",
 				"exit-x": "^0.2.2",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-worker": "30.2.0",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
 				"slash": "^3.0.0",
 				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
@@ -1913,77 +1503,10 @@
 				}
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/@jest/schemas": {
-			"version": "30.0.5",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1994,13 +1517,13 @@
 			}
 		},
 		"node_modules/@jest/snapshot-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
-			"integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"natural-compare": "^1.4.0"
@@ -2025,14 +1548,14 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
-			"integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"collect-v8-coverage": "^1.0.2"
 			},
@@ -2041,15 +1564,15 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
-			"integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.2.0",
+				"@jest/test-result": "30.4.1",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -2057,24 +1580,23 @@
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-			"integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"babel-plugin-istanbul": "^7.0.1",
 				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-util": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
 				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
 				"write-file-atomic": "^5.0.1"
@@ -2083,46 +1605,15 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/transform/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/transform/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/@jest/types": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.5",
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
@@ -2169,7 +1660,6 @@
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
@@ -2243,16 +1733,28 @@
 			}
 		},
 		"node_modules/@langchain/classic/node_modules/openai": {
-			"version": "6.44.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-			"integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
+			"integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
 				"ws": {
 					"optional": true
 				},
@@ -2277,7 +1779,6 @@
 			"integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"@standard-schema/spec": "^1.1.0",
@@ -2297,21 +1798,20 @@
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@langchain/langgraph": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.4.tgz",
-			"integrity": "sha512-20p+/xHRIUIEkk6dsoA576X7D5+FY+LkShsGjBpKrwATzQU0IJ2dfpBaP+4Z4wwpL9ArpDxjoRQR58kycdxU8A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
+			"integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/langgraph-checkpoint": "^1.1.2",
-				"@langchain/langgraph-sdk": "~1.9.23",
-				"@langchain/protocol": "^0.0.16",
+				"@langchain/langgraph-checkpoint": "^1.1.3",
+				"@langchain/langgraph-sdk": "~1.9.26",
+				"@langchain/protocol": "^0.0.18",
 				"@standard-schema/spec": "1.1.0"
 			},
 			"engines": {
@@ -2319,19 +1819,13 @@
 			},
 			"peerDependencies": {
 				"@langchain/core": "^1.1.48",
-				"zod": "^3.25.32 || ^4.2.0",
-				"zod-to-json-schema": "^3.x"
-			},
-			"peerDependenciesMeta": {
-				"zod-to-json-schema": {
-					"optional": true
-				}
+				"zod": "^3.25.32 || ^4.2.0"
 			}
 		},
 		"node_modules/@langchain/langgraph-checkpoint": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.2.tgz",
-			"integrity": "sha512-m5Xd7W3G9JrlEhFZ5WAcqZPgE46R9gr1gFDFaVqEKeuwin3tgEp0jlPbru+iFXCug338DcQjFS/Kuuci21ydvw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
+			"integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2342,13 +1836,13 @@
 			}
 		},
 		"node_modules/@langchain/langgraph-sdk": {
-			"version": "1.9.23",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.23.tgz",
-			"integrity": "sha512-JF5TWOrrKaMn9D7O0xT/9e9t3CpDRd8DUyKQdcbGswDsWdlI+04E9E1Lxv361tMu5pNYhval3iJPAwGxUuqi4w==",
+			"version": "1.9.27",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.27.tgz",
+			"integrity": "sha512-EHGFsxawniLw2pGVUDLSSdMriASIP4oz0Mihytb50iRsIqhmODzGBWW7iLWA/0hqavggNpqjat4WD7LjmxiXSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/protocol": "^0.0.16",
+				"@langchain/protocol": "^0.0.18",
 				"@types/json-schema": "^7.0.15",
 				"p-queue": "^9.0.1",
 				"p-retry": "^7.1.1"
@@ -2383,9 +1877,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-			"integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+			"version": "9.3.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.2.tgz",
+			"integrity": "sha512-pCsnA4piiqkrwAJ555Xh/lc717SijJrTBr96P1q6BRnUdm2XPB4v91oiXVAUr5HbIbXW4D8kIslfJUE28Rud6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2431,16 +1925,28 @@
 			}
 		},
 		"node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.44.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-			"integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
+			"integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
 				"ws": {
 					"optional": true
 				},
@@ -2460,9 +1966,9 @@
 			}
 		},
 		"node_modules/@langchain/protocol": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
-			"integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
+			"integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2482,44 +1988,84 @@
 				"@langchain/core": "^1.0.0"
 			}
 		},
+		"node_modules/@lezer/common": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+			"integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.3.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+			"integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+			"integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+			"license": "MIT"
+		},
+		"node_modules/@n8n_io/ai-assistant-sdk": {
+			"version": "1.25.0",
+			"resolved": "https://registry.npmjs.org/@n8n_io/ai-assistant-sdk/-/ai-assistant-sdk-1.25.0.tgz",
+			"integrity": "sha512-7V4dwVuHIkLdwd7Cx0k1miwr3KttC4rLQ+zVLftBMmSDx6n+0/W4a8BGhwrVHNx6uQwA1UGEWz+wSfO+gtBA4Q==",
+			"dev": true,
+			"license": "LicenseRef-n8n-enterprise",
+			"engines": {
+				"node": ">=20.15",
+				"pnpm": ">=8.14"
+			}
+		},
 		"node_modules/@n8n/ai-node-sdk": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.16.1.tgz",
-			"integrity": "sha512-pXTDQxG2Q/6NCdIHS9IQt8XBwzItAIx8lzPT8mAFs+bzLtkDBQh61V/7dWHEBwfeKMkXjcuKqBEg7YpA9TSPbA==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.21.2.tgz",
+			"integrity": "sha512-y1GhgPYqDkqtrUbWmICGPH9KLBPbvMTe3KAHhtsiJHOoGuBYV9cA8+siG620LeArxGcEFux26V/sXiXO3468lA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/ai-utilities": "0.19.1"
+				"@n8n/ai-utilities": "0.24.2"
 			}
 		},
 		"node_modules/@n8n/ai-utilities": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.19.1.tgz",
-			"integrity": "sha512-QlKXt3Vt8fhUqBTP8dH+alCoFZaIKrqtk0Mp8UcOqxEY9klEwShihO2gNhXqVVx8yf/KWvnnhKsUYkV6w0mgZw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.24.2.tgz",
+			"integrity": "sha512-D3CFtpW/qgRKBMOUei6w4r0q0zBFz8UeGA4x5iaN/zFPobfKDOh/VJ6CJE1D2RHuF0zvedTReOjNL7OSRd9ggQ==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@langchain/classic": "1.0.27",
 				"@langchain/community": "1.1.27",
-				"@langchain/core": "1.1.41",
+				"@langchain/core": "1.2.0",
 				"@langchain/openai": "1.4.4",
 				"@langchain/textsplitters": "1.0.1",
-				"@n8n/config": "2.24.1",
-				"@n8n/typescript-config": "1.5.0",
-				"@n8n/utils": "1.34.0",
+				"@n8n/api-types": "1.31.2",
+				"@n8n/backend-network": "1.5.2",
+				"@n8n/config": "2.29.1",
+				"@n8n/typescript-config": "1.9.0",
+				"@n8n/utils": "1.39.0",
 				"@thednp/dommatrix": "^2.0.12",
-				"https-proxy-agent": "7.0.6",
 				"js-tiktoken": "1.0.21",
 				"langchain": "1.2.30",
+				"lodash": "4.18.1",
+				"n8n-workflow": "2.31.2",
 				"pdf-parse": "2.4.5",
-				"proxy-from-env": "^1.1.0",
 				"tmp-promise": "3.0.3",
 				"undici": "^6.24.0",
 				"zod": "3.25.67",
 				"zod-to-json-schema": "3.23.3"
-			},
-			"peerDependencies": {
-				"n8n-workflow": "*"
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community": {
@@ -3036,16 +2582,28 @@
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.44.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-			"integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
+			"integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
 				"ws": {
 					"optional": true
 				},
@@ -3064,77 +2622,119 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core": {
-			"version": "1.1.41",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
-			"integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cfworker/json-schema": "^4.0.2",
-				"@standard-schema/spec": "^1.1.0",
-				"ansi-styles": "^5.0.0",
-				"camelcase": "6",
-				"decamelize": "1.2.0",
-				"js-tiktoken": "^1.0.12",
-				"langsmith": ">=0.5.0 <1.0.0",
-				"mustache": "^4.2.0",
-				"p-queue": "^6.6.2",
-				"uuid": "^11.1.0",
-				"zod": "^3.25.76 || ^4"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/uuid": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/esm/bin/uuid"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/@n8n/config": {
-			"version": "2.24.1",
-			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.24.1.tgz",
-			"integrity": "sha512-qdLCqpLUqMvAYIf3JaMDgzYazkQYHLIWS7ToPIIYinf3Qa0PsFFceKMEZHP5DsggTA0gcRxrcDoJQhozA4ITTA==",
+		"node_modules/@n8n/api-types": {
+			"version": "1.31.2",
+			"resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.31.2.tgz",
+			"integrity": "sha512-2R3g1+1CsufLup86gb8l2Ew4ZyrH49QhZXL+ohGx7T9fVLHO4IdSm6sfbRplslOhUFA0r3JSKysVrj34R9to6w==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/constants": "0.26.0",
-				"@n8n/di": "0.13.0",
+				"@n8n_io/ai-assistant-sdk": "1.25.0",
+				"@n8n/permissions": "0.68.0",
+				"n8n-workflow": "2.31.2",
+				"xss": "1.0.15"
+			},
+			"peerDependencies": {
+				"zod": "3.25.67"
+			}
+		},
+		"node_modules/@n8n/backend-common": {
+			"version": "1.31.2",
+			"resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.31.2.tgz",
+			"integrity": "sha512-BXxtrzcy0xDc6u4TaqXbeL7sZt+9SS4jsWvg2vk0drwZxbEks7D8Mfx2Rw5z7tnmdkWKnRhAuKr7MNHzWVX1ZA==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/config": "2.29.1",
+				"@n8n/constants": "0.31.0",
+				"@n8n/decorators": "1.31.2",
+				"@n8n/di": "0.15.0",
+				"@n8n/utils": "1.39.0",
+				"callsites": "3.1.0",
+				"flatted": "3.4.2",
+				"logform": "2.6.1",
+				"n8n-workflow": "2.31.2",
+				"picocolors": "1.0.1",
+				"reflect-metadata": "0.2.2",
+				"stream-json": "1.9.1",
+				"winston": "3.14.2",
+				"yargs-parser": "21.1.1"
+			}
+		},
+		"node_modules/@n8n/backend-network": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.5.2.tgz",
+			"integrity": "sha512-lPby9p02pDfOSMkK8AXPKmgZVjyjFq21RuPQByT2wUu0PcIpQ2xmecr7GSENhKw2DDuBQGBev/33wkVGeTp+2g==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/backend-common": "1.31.2",
+				"@n8n/config": "2.29.1",
+				"@n8n/constants": "0.31.0",
+				"@n8n/di": "0.15.0",
+				"@n8n/utils": "1.39.0",
+				"axios": "1.18.0",
+				"cache-manager": "5.2.3",
+				"form-data": "4.0.6",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"iconv-lite": "0.6.3",
+				"n8n-workflow": "2.31.2",
+				"proxy-from-env": "^1.1.0",
+				"qs": "6.15.2",
+				"reflect-metadata": "0.2.2",
+				"undici": "^7.28.0",
+				"zod": "3.25.67"
+			}
+		},
+		"node_modules/@n8n/backend-network/node_modules/undici": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/@n8n/config": {
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.29.1.tgz",
+			"integrity": "sha512-ccL6ksRS6HiQkxfNxYEc3db4VS8HCwmMJMqaXu7B4f4e6qm13efj2CUl2W60sATezQ+my1ETysfSgy71PbfvzA==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/constants": "0.31.0",
+				"@n8n/di": "0.15.0",
 				"reflect-metadata": "0.2.2",
 				"zod": "3.25.67"
 			}
 		},
 		"node_modules/@n8n/constants": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.26.0.tgz",
-			"integrity": "sha512-25BYGmGBD6zmbrbwJys0bHzmSiEth374kmzii3HC8jVfx0Lyms+vh1rzjAnvcvcY/zkJ8ic3fDvewvpzasb6AQ==",
-			"dev": true,
+			"version": "0.31.0",
+			"resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.31.0.tgz",
+			"integrity": "sha512-qUffAbe5M5Y6IT4Dbjvts6clFSbZHKlfBDool0q5EYlq6fw5aRvvA9K31gxuySxgGaGLazXiflwDlv7OEcSjEA==",
 			"license": "SEE LICENSE IN LICENSE.md"
 		},
+		"node_modules/@n8n/decorators": {
+			"version": "1.31.2",
+			"resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.31.2.tgz",
+			"integrity": "sha512-aK2mwvS47lKlkbI8DzEx7UaxoxAlrmE+d78D1RBh5t3jRUxOsofSR17Y3f9AUkSm7yMyXxup7EX7JRp6eDy0Yw==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/api-types": "1.31.2",
+				"@n8n/constants": "0.31.0",
+				"@n8n/di": "0.15.0",
+				"@n8n/permissions": "0.68.0",
+				"lodash": "4.18.1",
+				"n8n-workflow": "2.31.2"
+			}
+		},
 		"node_modules/@n8n/di": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.13.0.tgz",
-			"integrity": "sha512-pxsmn2UqcSnMQwb2zSSZcZZMViiOUnJVrRLoDZPhUZVbdAhmttQJGtm82+6hWPEc4wAOAMFbO1U3X53Wu29Y2g==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.15.0.tgz",
+			"integrity": "sha512-ZsItCGrn41nTluT9XT/uSomOGt1ini08MesITAdarjOGXKHMoDrEiToNPzeiqtqbRGp12D1DONiwyWkrwxfskQ==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -3142,19 +2742,18 @@
 			}
 		},
 		"node_modules/@n8n/errors": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.10.0.tgz",
-			"integrity": "sha512-Qle4gCsx7qtDRMdie3YkjuXPuo369PP32cR9Svb+INwcjLMxNzmnbJ66jFnOmLn0ntwBccUw1IecJ6axwyTgBQ==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.12.0.tgz",
+			"integrity": "sha512-McWRCwnUG7vupVRmcvcIfMXVDdN5kF1JZJvfXBRBx80PHPVqGtOHXaavbe7iKdxeS3VnkW/mo5Ig04IqikG6nQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
 				"callsites": "3.1.0"
 			}
 		},
 		"node_modules/@n8n/eslint-plugin-community-nodes": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.20.0.tgz",
-			"integrity": "sha512-5KCHQIWlL79H+YRkoG1UVMZ5OwHJ2i4m2/yYOMESTqPyLbgcRpiQBvnZHCbbSXUjImZ6vtSAPCzvSwYGW28pVQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.25.0.tgz",
+			"integrity": "sha512-qSOrldDCeZmV1eOds/SWqbS/YMyjZrnRRJI1/VDxBU7aa+Jk2jO4DkKp7R5hvhjRH3CosQ0+hW/4WP1xxxuWPw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -3168,14 +2767,13 @@
 			}
 		},
 		"node_modules/@n8n/expression-runtime": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.18.1.tgz",
-			"integrity": "sha512-bZ4rSOHWs3CWI0KApS9SL+qR+ntXjw22uQdtSfVKq2uGpr8uwA55y3FlQhLBkskQNGGYLf7fW5tmH6LEy69iXA==",
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.22.0.tgz",
+			"integrity": "sha512-RglPWm8FZvzrBj6q90dR6MMhlF+e/EBJFkigEpB3u7U0CEOM6rwNQ6aVRgORK9MlFM0isnNutssu4jKOrxhugg==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "0.10.0",
-				"@n8n/tournament": "1.4.0",
+				"@n8n/errors": "0.12.0",
+				"@n8n/tournament": "1.7.0",
 				"isolated-vm": "^6.1.2",
 				"jmespath": "0.16.0",
 				"js-base64": "3.7.8",
@@ -3189,20 +2787,22 @@
 			}
 		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.35.1",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.35.1.tgz",
-			"integrity": "sha512-MhS7z3zJeUa+8YOztALZo7CGVAnhyS3kg+IiUYvxfwwKa6AOCicqK8IQyi2dkTeGPMSj66N9Ad0Fz5oG0QcVFQ==",
+			"version": "0.40.2",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.40.2.tgz",
+			"integrity": "sha512-uXgDHwewzpc9p1CDNwMi3MIfLzzo5AM8sevbx5q4nEq6OyhyKorZ+jv4xd/HyRadRHixiSAqIafoOAKajw4JFw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/ai-node-sdk": "0.16.1",
-				"@n8n/eslint-plugin-community-nodes": "0.20.0",
+				"@eslint/js": "^9.29.0",
+				"@n8n/ai-node-sdk": "0.21.2",
+				"@n8n/eslint-plugin-community-nodes": "0.25.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
+				"eslint": "9.29.0",
 				"eslint-import-resolver-typescript": "^4.4.3",
 				"eslint-plugin-import-x": "^4.15.2",
-				"eslint-plugin-n8n-nodes-base": "1.16.5",
+				"eslint-plugin-n8n-nodes-base": "^1.16.7",
 				"fast-glob": "3.2.12",
 				"handlebars": "4.7.9",
 				"picocolors": "1.0.1",
@@ -3216,7 +2816,7 @@
 				"n8n-node": "bin/n8n-node.mjs"
 			},
 			"peerDependencies": {
-				"eslint": "9.29.0"
+				"eslint": ">= 9"
 			}
 		},
 		"node_modules/@n8n/node-cli/node_modules/prettier": {
@@ -3235,37 +2835,41 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
-		"node_modules/@n8n/tournament": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.4.0.tgz",
-			"integrity": "sha512-llDdmIj3Kdfq2vX/NpLBOUU4kLjhITtIMeJmOSTApAOeAArj1D45ey4D7CFaYcYsPBw6DgF0vxifyskPDlgekw==",
+		"node_modules/@n8n/permissions": {
+			"version": "0.68.0",
+			"resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.68.0.tgz",
+			"integrity": "sha512-FL3cE0ufOGJznDQjs40L1kjcUsXWByp6kDaj3xlzLPXr95Ql0/HWxN1L94jbgYtx7T6XWPu3USJqT5Iu9WFJTg==",
+			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
+			"dependencies": {
+				"zod": "3.25.67"
+			}
+		},
+		"node_modules/@n8n/tournament": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.7.0.tgz",
+			"integrity": "sha512-0tyxRB7In8A1M58EgsRQR1/FNB5vxnqX3te3NFzT4/P15LKN85WhrwPn+N8LOiMOHoqlLbcl9OXdeNurt2PuVA==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"ast-types": "^0.16.1",
 				"esprima-next": "^5.8.4",
 				"recast": "^0.22.0"
-			},
-			"engines": {
-				"node": ">=20.15",
-				"pnpm": ">=9.5"
 			}
 		},
 		"node_modules/@n8n/typescript-config": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.5.0.tgz",
-			"integrity": "sha512-lRqZYmU0tRPAlVmUDfHBlgceE3GbQ5Zqkomrxs2wq5Kif8QqokJvB2T2xzYRrP3WGMDQbZqXeKs2E8Dm5t+nIw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.9.0.tgz",
+			"integrity": "sha512-/YI8LGcaU0b8VqNuvrbvzgSfpAvaxbeQexV1h/edX5/U4Ow6SSAAJ/ZYPVS6eaVZXzKBouvTPYo5RmI0j/Wk5g==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md"
 		},
 		"node_modules/@n8n/utils": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.34.0.tgz",
-			"integrity": "sha512-JOaQXZLIBBYN0rmXDd8VXK3OwXPMw1PdCXGSy+5xf6arPzm9+gkGRbrPcgh3vv4/sLbtfqyM7O5ohQK/axjMzQ==",
-			"dev": true,
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.39.0.tgz",
+			"integrity": "sha512-vFlcgSFFqJ6jX5T5fKKqeqXL2tOTt3rH/clvRqiUXhwKUuf3CHBY74p+785/JbH3RdcxcMBi682gHn4enJHijg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/constants": "0.26.0",
+				"@n8n/constants": "0.31.0",
 				"nanoid": "3.3.8"
 			}
 		},
@@ -3566,6 +3170,119 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/api-logs": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+			"integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/core": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+			"integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+			"integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.220.0",
+				"import-in-the-middle": "^3.0.0",
+				"require-in-the-middle": "^8.0.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+			"integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+			"integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/resources": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+			"integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/resources": "2.9.0",
+				"@opentelemetry/sdk-trace": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@package-json/types": {
 			"version": "0.0.12",
 			"resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
@@ -3598,17 +3315,130 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.61.0"
+				"playwright": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/conventions": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+			"integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@sentry/core": {
+			"version": "10.67.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.67.0.tgz",
+			"integrity": "sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/node": {
+			"version": "10.67.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.67.0.tgz",
+			"integrity": "sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==",
+			"license": "MIT",
+			"dependencies": {
+				"@opentelemetry/api": "^1.9.1",
+				"@opentelemetry/instrumentation": "^0.220.0",
+				"@opentelemetry/sdk-trace-base": "^2.9.0",
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.67.0",
+				"@sentry/node-core": "10.67.0",
+				"@sentry/opentelemetry": "10.67.0",
+				"@sentry/server-utils": "10.67.0",
+				"import-in-the-middle": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/node-core": {
+			"version": "10.67.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.67.0.tgz",
+			"integrity": "sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.67.0",
+				"@sentry/opentelemetry": "10.67.0",
+				"import-in-the-middle": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+				"@opentelemetry/instrumentation": ">=0.57.1 <1",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/core": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-http": {
+					"optional": true
+				},
+				"@opentelemetry/instrumentation": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@sentry/opentelemetry": {
+			"version": "10.67.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.67.0.tgz",
+			"integrity": "sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.67.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+			}
+		},
+		"node_modules/@sentry/server-utils": {
+			"version": "10.67.0",
+			"resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.67.0.tgz",
+			"integrity": "sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==",
+			"license": "MIT",
+			"dependencies": {
+				"@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+				"@apm-js-collab/tracing-hooks": "^0.13.0",
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.67.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3632,13 +3462,24 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@so-ric/colorspace": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+			"integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color": "^5.0.2",
+				"text-hex": "1.0.x"
 			}
 		},
 		"node_modules/@standard-schema/spec": {
@@ -3769,7 +3610,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -3847,13 +3687,6 @@
 				"form-data": "^4.0.4"
 			}
 		},
-		"node_modules/@types/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3868,6 +3701,13 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.35",
@@ -4630,14 +4470,13 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
 			"license": "MIT",
-			"engines": {
-				"node": ">=8"
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"node_modules/assert": {
@@ -4645,7 +4484,6 @@
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
 			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"is-nan": "^1.3.2",
@@ -4659,12 +4497,20 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
 			"integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/astring": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+			"integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+			"license": "MIT",
+			"bin": {
+				"astring": "bin/astring"
 			}
 		},
 		"node_modules/async": {
@@ -4678,15 +4524,13 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -4701,9 +4545,7 @@
 			"version": "1.18.0",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
 			"integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
@@ -4715,9 +4557,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"debug": "4"
 			},
@@ -4729,9 +4569,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -4744,24 +4582,22 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
 			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-			"integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "30.2.0",
+				"@jest/transform": "30.4.1",
 				"@types/babel__core": "^7.20.5",
 				"babel-plugin-istanbul": "^7.0.1",
-				"babel-preset-jest": "30.2.0",
+				"babel-preset-jest": "30.4.0",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
@@ -4794,9 +4630,9 @@
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-			"integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4834,13 +4670,13 @@
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-			"integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "30.2.0",
+				"babel-plugin-jest-hoist": "30.4.0",
 				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
@@ -4892,6 +4728,15 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -5005,12 +4850,41 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/buildcheck": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+			"integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/cache-manager": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.2.3.tgz",
+			"integrity": "sha512-9OErI8fksFkxAMJ8Mco0aiZSdphyd90HcKiOMJQncSlU1yq/9lHHxrT8PDayxrmr9IIIZPOAEfXuGSD7g29uog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash.clonedeep": "^4.5.0",
+				"lru-cache": "^9.1.2"
+			}
+		},
+		"node_modules/cache-manager/node_modules/lru-cache": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+			"integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "14 || >=16.14"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
 			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -5029,7 +4903,6 @@
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -5043,7 +4916,6 @@
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -5177,7 +5049,6 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -5202,7 +5073,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
 			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/clean-stack": {
@@ -5294,6 +5164,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/color": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5312,18 +5196,70 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
 		},
+		"node_modules/color-string": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/color-string/node_modules/color-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/color/node_modules/color-convert": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.6"
+			}
+		},
+		"node_modules/color/node_modules/color-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/comment-parser": {
 			"version": "1.4.7",
@@ -5349,6 +5285,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/crelt": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+			"integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+			"license": "MIT"
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5369,16 +5325,21 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/cssfilter": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+			"integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -5390,16 +5351,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/dedent": {
@@ -5439,7 +5390,6 @@
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -5457,7 +5407,6 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -5475,7 +5424,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -5488,33 +5436,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/dir-glob": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/doctrine": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/dotenv": {
@@ -5536,7 +5457,6 @@
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -5606,6 +5526,13 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"license": "MIT"
 		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -5621,7 +5548,6 @@
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5631,17 +5557,21 @@
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
 			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0"
 			},
@@ -5654,7 +5584,6 @@
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"get-intrinsic": "^1.2.6",
@@ -5847,14 +5776,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base": {
-			"version": "1.16.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.16.5.tgz",
-			"integrity": "sha512-/Bx2xj1ZzwEN+KQmnf7i0QRzgNMuphythQI2qXHoJQd8nm6aJGC9ZyVmDBFkM9P1ZfVBgBK7bDdjNxcbIK8Hgw==",
+			"version": "1.16.7",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.16.7.tgz",
+			"integrity": "sha512-lKo+stn4t2jXX/ZdmJv2ClUQnRZLwSOyqfqsYgD6I/wYwy9bqA6mna4CEzdQNFVg5f3/RODpd/JQMiITARY92g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "^6.21.0",
+				"@typescript-eslint/utils": "^8.35.0",
 				"camel-case": "^4.1.2",
 				"indefinite": "^2.5.1",
 				"pascal-case": "^3.1.2",
@@ -5865,493 +5794,6 @@
 			"engines": {
 				"node": ">=20.15",
 				"pnpm": ">=9.6"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ajv": "^6.12.4",
-				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/js": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.1",
-				"@humanwhocodes/config-array": "^0.13.0",
-				"@humanwhocodes/module-importer": "^1.0.1",
-				"@nodelib/fs.walk": "^1.2.8",
-				"@ungap/structured-clone": "^1.2.0",
-				"ajv": "^6.12.4",
-				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
-				"debug": "^4.3.2",
-				"doctrine": "^3.0.0",
-				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1",
-				"esquery": "^1.4.2",
-				"esutils": "^2.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^6.0.1",
-				"find-up": "^5.0.0",
-				"glob-parent": "^6.0.2",
-				"globals": "^13.19.0",
-				"graphemer": "^1.4.0",
-				"ignore": "^5.2.0",
-				"imurmurhash": "^0.1.4",
-				"is-glob": "^4.0.0",
-				"is-path-inside": "^3.0.3",
-				"js-yaml": "^4.1.0",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.4.1",
-				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"strip-ansi": "^6.0.1",
-				"text-table": "^0.2.0"
-			},
-			"bin": {
-				"eslint": "bin/eslint.js"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint-scope": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/espree": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"acorn": "^8.9.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/file-entry-cache": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"flat-cache": "^3.0.4"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/flat-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"flatted": "^3.2.9",
-				"keyv": "^4.5.3",
-				"rimraf": "^3.0.2"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/ts-api-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.2.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -6477,7 +5919,6 @@
 			"resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.4.tgz",
 			"integrity": "sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==",
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -6490,7 +5931,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
 			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -6516,7 +5956,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
@@ -6698,6 +6137,13 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6832,11 +6278,17 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/follow-redirects": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
 			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -6844,7 +6296,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -6859,7 +6310,6 @@
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"is-callable": "^1.2.7"
 			},
@@ -6891,9 +6341,7 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
 			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
@@ -6955,7 +6403,6 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -6965,7 +6412,6 @@
 			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
 			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -6994,7 +6440,6 @@
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -7029,7 +6474,6 @@
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
@@ -7107,9 +6551,9 @@
 			"license": "MIT"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7145,33 +6589,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7185,14 +6607,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/graphemer": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.9",
@@ -7231,7 +6645,6 @@
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -7244,7 +6657,6 @@
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7257,7 +6669,6 @@
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -7273,7 +6684,6 @@
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
 			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -7287,6 +6697,20 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
@@ -7324,9 +6748,9 @@
 			}
 		},
 		"node_modules/ibm-cloud-sdk-core": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.5.0.tgz",
-			"integrity": "sha512-ot6sGHAvSnd/ZSU4ZFn+m7i+xcFo3pmA3qm2JmEndDkMsuNR8HLdUeJ5iBbmkUfCGbf2ccTu/GvoJgFetyO6XA==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.6.0.tgz",
+			"integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -7404,6 +6828,19 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -7451,6 +6888,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-in-the-middle": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
+			"integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cjs-module-lexer": "^2.2.0",
+				"es-module-lexer": "^2.2.0",
+				"module-details-from-path": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/import-local": {
@@ -7526,7 +6977,6 @@
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -7549,8 +6999,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/is-bun-module": {
 			"version": "2.0.0",
@@ -7567,7 +7016,6 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7625,7 +7073,6 @@
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
 			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.4",
 				"generator-function": "^2.0.0",
@@ -7658,7 +7105,6 @@
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
 			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
@@ -7693,23 +7139,11 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-path-inside": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -7741,7 +7175,6 @@
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
 			},
@@ -7778,7 +7211,6 @@
 			"integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
 			"hasInstallScript": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"node-gyp-build": "^4.8.4"
 			},
@@ -7920,16 +7352,16 @@
 			"license": "ISC"
 		},
 		"node_modules/jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
-			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
 				"import-local": "^3.2.0",
-				"jest-cli": "30.2.0"
+				"jest-cli": "30.4.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -7947,75 +7379,44 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
-			"integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"execa": "^5.1.1",
-				"jest-util": "30.2.0",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-changed-files/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-changed-files/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-circus": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
-			"integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/expect": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"co": "^4.6.0",
 				"dedent": "^1.6.0",
 				"is-generator-fn": "^2.1.0",
-				"jest-each": "30.2.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0",
-				"pretty-format": "30.2.0",
+				"pretty-format": "30.4.1",
 				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
@@ -8024,131 +7425,22 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-circus/node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-circus/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-cli": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
-			"integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"chalk": "^4.1.2",
 				"exit-x": "^0.2.2",
 				"import-local": "^3.2.0",
-				"jest-config": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -8166,66 +7458,34 @@
 				}
 			}
 		},
-		"node_modules/jest-cli/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-config": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
-			"integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
 				"@jest/get-type": "30.1.0",
-				"@jest/pattern": "30.0.1",
-				"@jest/test-sequencer": "30.2.0",
-				"@jest/types": "30.2.0",
-				"babel-jest": "30.2.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"deepmerge": "^4.3.1",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.2.0",
-				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-runner": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"parse-json": "^5.2.0",
-				"pretty-format": "30.2.0",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -8249,52 +7509,6 @@
 				}
 			}
 		},
-		"node_modules/jest-config/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-config/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-config/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-diff": {
 			"version": "30.4.1",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
@@ -8312,9 +7526,9 @@
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8325,149 +7539,57 @@
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
-			"integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"chalk": "^4.1.2",
-				"jest-util": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-each/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
-			"integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0"
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-			"integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"anymatch": "^3.1.3",
 				"fb-watchman": "^2.0.2",
 				"graceful-fs": "^4.2.11",
-				"jest-regex-util": "30.0.1",
-				"jest-util": "30.2.0",
-				"jest-worker": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
 				"walker": "^1.0.8"
 			},
 			"engines": {
@@ -8477,28 +7599,10 @@
 				"fsevents": "^2.3.3"
 			}
 		},
-		"node_modules/jest-haste-map/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-haste-map/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8509,29 +7613,14 @@
 			}
 		},
 		"node_modules/jest-leak-detector": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
-			"integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-leak-detector/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8575,62 +7664,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-message-util/node_modules/@jest/pattern": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"jest-regex-util": "30.4.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/@jest/types": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.4.0",
-				"@jest/schemas": "30.4.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/jest-regex-util": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-message-util/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -8659,62 +7692,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-mock/node_modules/@jest/pattern": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"jest-regex-util": "30.4.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@jest/types": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.4.0",
-				"@jest/schemas": "30.4.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/jest-regex-util": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-pnp-resolver": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -8734,9 +7711,9 @@
 			}
 		},
 		"node_modules/jest-regex-util": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8744,18 +7721,18 @@
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
-			"integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.4.1",
 				"jest-pnp-resolver": "^1.2.3",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"slash": "^3.0.0",
 				"unrs-resolver": "^1.7.11"
 			},
@@ -8764,77 +7741,46 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
-			"integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-regex-util": "30.0.1",
-				"jest-snapshot": "30.2.0"
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-resolve/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-resolve/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
-			"integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/environment": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
-				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.2.0",
-				"jest-haste-map": "30.2.0",
-				"jest-leak-detector": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-resolve": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-watcher": "30.2.0",
-				"jest-worker": "30.2.0",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
@@ -8842,100 +7788,33 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runner/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-runner/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-runtime": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
-			"integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/globals": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
 				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"cjs-module-lexer": "^2.1.0",
 				"collect-v8-coverage": "^1.0.2",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
@@ -8943,92 +7822,10 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runtime/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-snapshot": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
-			"integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9037,177 +7834,22 @@
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1",
 				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.2.0",
+				"@jest/expect-utils": "30.4.1",
 				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/snapshot-utils": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"babel-preset-current-node-syntax": "^1.2.0",
 				"chalk": "^4.1.2",
-				"expect": "30.2.0",
+				"expect": "30.4.1",
 				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.2.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
-				"pretty-format": "30.2.0",
+				"jest-diff": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1",
 				"semver": "^7.7.2",
 				"synckit": "^0.11.8"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/@jest/expect-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "30.2.0",
-				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9231,62 +7873,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-util/node_modules/@jest/pattern": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"jest-regex-util": "30.4.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@jest/types": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.4.0",
-				"@jest/schemas": "30.4.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/jest-regex-util": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
 		"node_modules/jest-util/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -9301,99 +7887,53 @@
 			}
 		},
 		"node_modules/jest-validate": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
-			"integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
 				"camelcase": "^6.3.0",
 				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "30.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-validate/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
-			"integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "30.2.0",
+				"jest-util": "30.4.1",
 				"string-length": "^4.0.2"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-watcher/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-watcher/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-worker": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-			"integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"@ungap/structured-clone": "^1.3.0",
-				"jest-util": "30.2.0",
+				"jest-util": "30.4.1",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.1.1"
 			},
@@ -9401,43 +7941,11 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-worker/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jmespath": {
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
 			"integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6.0"
 			}
@@ -9446,8 +7954,7 @@
 			"version": "3.7.8",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
 			"integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/js-tiktoken": {
 			"version": "1.0.21",
@@ -9516,6 +8023,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9558,7 +8071,6 @@
 			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.2.tgz",
 			"integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"jsonrepair": "bin/cli.js"
 			}
@@ -9592,7 +8104,6 @@
 			"resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
 			"integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -9642,6 +8153,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/langchain": {
 			"version": "1.2.30",
 			"resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.30.tgz",
@@ -9687,9 +8205,9 @@
 			}
 		},
 		"node_modules/langsmith": {
-			"version": "0.7.10",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.10.tgz",
-			"integrity": "sha512-3EjJx9zGMzqF60eT9JADHF+Hn/T5ayTgEVp4d3M5yvJIJi3q6seX0p5jT8ecBCWBi1kIvvssWrcDxfwgSier7Q==",
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.4.tgz",
+			"integrity": "sha512-e2zdhPUV/mLwVv+Gde/0gLGnCOE/zvZ3gGNh/rvkzrxsDz7qgUT4CJVUmJE2GwQ1A3FPtWKzy08oo//VV1nBFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9805,8 +8323,14 @@
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
+		},
+		"node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
@@ -9878,6 +8402,24 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/logform": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
+			"integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
 		"node_modules/lower-case": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -9903,9 +8445,17 @@
 			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
 			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/make-dir": {
@@ -9953,7 +8503,6 @@
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -9963,7 +8512,6 @@
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
 			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"charenc": "0.0.2",
 				"crypt": "0.0.2",
@@ -9987,6 +8535,15 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/meriyah": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+			"integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -10006,7 +8563,6 @@
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -10016,7 +8572,6 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -10070,11 +8625,16 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/module-details-from-path": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+			"license": "MIT"
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mustache": {
@@ -10088,27 +8648,33 @@
 			}
 		},
 		"node_modules/n8n-workflow": {
-			"version": "2.27.1",
-			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.27.1.tgz",
-			"integrity": "sha512-3kNIcWWeJ3bNLl6jtIcyjBcbdCAfme3kC6VaNnKvrYUWCyG2vN0WvfCIMTAx9sDZitOJAAVhbFLx3DvmsZKM1A==",
+			"version": "2.31.2",
+			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.31.2.tgz",
+			"integrity": "sha512-xeXHNsGlLribk2DWnL3z29nbBdc+h+lDdsx//9manI53HuOCgvE2AvcteE909PVHkAyOMkaT0CS4Y69nyss1Lw==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "0.10.0",
-				"@n8n/expression-runtime": "0.18.1",
-				"@n8n/tournament": "1.4.0",
+				"@codemirror/autocomplete": "6.20.0",
+				"@n8n/errors": "0.12.0",
+				"@n8n/expression-runtime": "0.22.0",
+				"@n8n/tournament": "1.7.0",
+				"@n8n/utils": "1.39.0",
+				"@sentry/core": "^10.55.0",
+				"@sentry/node": "^10.55.0",
 				"ast-types": "0.16.1",
+				"axios": "1.18.0",
 				"callsites": "3.1.0",
 				"esprima-next": "5.8.4",
-				"form-data": "4.0.4",
+				"form-data": "4.0.6",
 				"jmespath": "0.16.0",
 				"js-base64": "3.7.8",
+				"json-schema": "0.4.0",
 				"jsonrepair": "3.13.2",
 				"jssha": "3.3.1",
 				"lodash": "4.18.1",
 				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"recast": "0.22.0",
+				"ssh2": "1.15.0",
 				"title-case": "3.0.3",
 				"transliteration": "2.3.5",
 				"uuid": "11.1.1",
@@ -10116,23 +8682,6 @@
 			},
 			"peerDependencies": {
 				"zod": "3.25.67"
-			}
-		},
-		"node_modules/n8n-workflow/node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/n8n-workflow/node_modules/uuid": {
@@ -10144,16 +8693,21 @@
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"uuid": "dist/esm/bin/uuid"
 			}
+		},
+		"node_modules/nan": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.8",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
 			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10258,7 +8812,6 @@
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
 			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -10305,12 +8858,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/object-is": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1"
@@ -10327,7 +8892,6 @@
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -10337,7 +8901,6 @@
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
 			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -10361,6 +8924,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -10645,16 +9218,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/pdf-parse": {
 			"version": "2.4.5",
 			"resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
@@ -10789,14 +9352,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.61.0"
+				"playwright-core": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -10809,9 +9372,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -10853,7 +9416,6 @@
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -10869,9 +9431,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+			"integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -10895,19 +9457,6 @@
 				"ansi-styles": "^5.2.0",
 				"react-is-18": "npm:react-is@^18.3.1",
 				"react-is-19": "npm:react-is@^19.2.5"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/pretty-format/node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -10975,6 +9524,22 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/querystringify": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -11004,13 +9569,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/react-is-18": {
 			"name": "react-is",
 			"version": "18.3.1",
@@ -11027,12 +9585,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/recast": {
 			"version": "0.22.0",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.22.0.tgz",
 			"integrity": "sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"assert": "^2.0.0",
 				"ast-types": "0.15.2",
@@ -11049,7 +9621,6 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
 			"integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -11071,6 +9642,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-in-the-middle": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.5",
+				"module-details-from-path": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
 			}
 		},
 		"node_modules/requires-port": {
@@ -11290,15 +9874,13 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -11311,15 +9893,36 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
 		"node_modules/sax": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
 			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"engines": {
 				"node": ">=11.0.0"
 			}
+		},
+		"node_modules/semifies": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+			"integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/semver": {
 			"version": "7.8.5",
@@ -11351,7 +9954,6 @@
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -11385,6 +9987,82 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/signal-exit": {
@@ -11444,6 +10122,23 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/ssh2": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+			"integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			},
+			"optionalDependencies": {
+				"cpu-features": "~0.0.9",
+				"nan": "^2.18.0"
+			}
+		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -11452,6 +10147,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/stack-utils": {
@@ -11475,6 +10180,33 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/stream-chain": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+			"integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/stream-json": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+			"integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"stream-chain": "^2.2.5"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-length": {
@@ -11679,6 +10411,12 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/style-mod": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"license": "MIT"
+		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -11779,13 +10517,12 @@
 				"node": "*"
 			}
 		},
-		"node_modules/text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.17",
@@ -11934,7 +10671,6 @@
 			"resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.3.5.tgz",
 			"integrity": "sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"yargs": "^17.5.1"
 			},
@@ -11944,6 +10680,16 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -11960,19 +10706,19 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.6",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-			"integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+			"version": "29.4.11",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+			"integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
 				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.8",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.3",
+				"semver": "^7.8.0",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -11989,7 +10735,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <6"
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -12041,6 +10787,12 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+			"license": "Unlicense"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -12285,7 +11037,6 @@
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
 			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"is-arguments": "^1.0.4",
@@ -12293,6 +11044,13 @@
 				"is-typed-array": "^1.1.3",
 				"which-typed-array": "^1.1.2"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "10.0.0",
@@ -12323,6 +11081,12 @@
 			"engines": {
 				"node": ">=10.12.0"
 			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"license": "MIT"
 		},
 		"node_modules/walker": {
 			"version": "1.0.8",
@@ -12386,7 +11150,6 @@
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
 			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.9",
@@ -12414,6 +11177,62 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/winston": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+			"integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.6.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.7.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport/node_modules/logform": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -12566,9 +11385,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -12593,7 +11412,6 @@
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
 			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -12607,9 +11425,25 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/xss": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+			"integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^2.20.3",
+				"cssfilter": "0.0.10"
+			},
+			"bin": {
+				"xss": "bin/xss"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
 			}
 		},
 		"node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@tehw0lf/n8n-nodes-toon",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "n8n node for TOON (Token-Oriented Object Notation) format conversion - bidirectional conversion between TOON and JSON with zero external dependencies",
-	"toonSpecVersion": "3.3.0",
+	"toonSpecVersion": "3.3.2",
 	"license": "MIT",
 	"homepage": "https://github.com/tehw0lf/n8n-nodes-toon#readme",
 	"keywords": [
@@ -46,12 +46,12 @@
 		]
 	},
 	"devDependencies": {
-		"@n8n/node-cli": "0.35.1",
+		"@n8n/node-cli": "0.40.2",
 		"@types/jest": "30.0.0",
 		"eslint": "9.29.0",
-		"jest": "30.2.0",
-		"prettier": "3.8.4",
-		"ts-jest": "29.4.6",
+		"jest": "30.4.2",
+		"prettier": "3.9.6",
+		"ts-jest": "29.4.11",
 		"typescript": "5.9.3"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## Summary

Tracks the upstream TOON spec release **3.3.0 → 3.3.2** and updates dev dependencies. Also fixes a spec-monitor bug this cycle exposed.

The TOON specification has moved out of `toon-format/toon` into its own repository, [`toon-format/spec`](https://github.com/toon-format/spec) (the old path now holds only a pointer stub). That repo versions **independently of its content**.

Our `SPEC.md` is byte-for-byte identical to upstream:

```
diff -u SPEC.md upstream    → exit 0
md5  local    67d10ef37f04ec4c7a532abbaba832ba
md5  upstream 67d10ef37f04ec4c7a532abbaba832ba
```

The spec CHANGELOG's newest content entry is still `[3.3] - 2026-05-21`, so 3.3.0 → 3.3.2 is repo tooling only (pnpm 11.13→11.14, eslint dev deps). **Patch bump accordingly: 1.3.2 → 1.3.3.**

## Dependency updates

| Package | Change |
|---|---|
| @n8n/node-cli | 0.35.1 → 0.40.2 |
| jest | 30.2.0 → 30.4.2 |
| ts-jest | 29.4.6 → 29.4.11 |
| prettier | 3.8.4 → 3.9.6 |

**TypeScript stays at 5.9.3.** 7.0.2 was attempted and reverted: `ts-jest` declares `peer typescript ">=4.3 <7"`, and no published ts-jest release supports TS 7 (29.4.11 is the newest that exists). Adopting it would require `--legacy-peer-deps` and a knowingly broken tree. Worth revisiting when ts-jest 30 lands.

**ESLint stays at 9.29.0** to match the version `@n8n/node-cli` depends on.

`n8n-workflow` left at `"*"` — deliberate, per 459052e (n8n community node requirement).

Side effect: audit findings drop from **14 (9 high) → 8 (2 high)**, all dev-only transitive deps. Nothing shipped; `files` is just `dist`.

## Spec monitor fix

The monitor compared **version strings only**, so any upstream release opened a *"Specification Update Available"* issue demanding updates to `SPEC.md`, the implementation and the tests. With the spec repo now versioning independently of content, that is no longer a valid proxy:

```
v3.3.0  67d10ef37f04ec4c7a532abbaba832ba  64241
v3.3.1  67d10ef37f04ec4c7a532abbaba832ba  64241
v3.3.2  67d10ef37f04ec4c7a532abbaba832ba  64241
```

All three tags ship an identical `SPEC.md` — v3.3.2 would have produced exactly that false alarm.

Now content is compared alongside the version, and the issue branches:

- **Content changed** → unchanged behaviour (review checklist + diff)
- **Content identical** → *"TOON Spec Version Bump (no content change)"*, asking only for a `toonSpecVersion` bump and a patch release

The diff step is gated on `spec_changed`, so it no longer renders an empty diff block.

## Docs

Refreshed stale references still claiming v3.0/v3.0.3 after the v3.3 upgrade (README.md, DEVELOPMENT.md), and documented the versioning nuance — including that `toonSpecVersion` tracks the spec repo, a different version line from `@toon-format/toon` (2.3.1).

Per-rule `*(v3.0.3)*` annotations in the compliance table are historical and intentionally left as-is; a note now says so.

## Validation

- `npm run lint` → exit 0 (1 pre-existing unrelated warning: themed icon variants)
- `npm test` → exit 0, **211/211**
- `npm run build` → exit 0
- Workflow YAML parses; compare logic simulated across up-to-date / version-bump-only / real-change, and both issue bodies rendered

Rebased on `origin/main` (`dd6c988`); all checks re-run after rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README and development guidance to reflect TOON Specification v3.3.
  - Clarified specification versioning, historical table annotations, and compliance details.

- **Bug Fixes**
  - Improved specification monitoring to distinguish version-only releases from substantive specification changes.
  - Issue reports now provide tailored guidance and include diffs only when specification content changes.

- **Release**
  - Updated package release metadata to version 1.3.3 and aligned the supported specification version with v3.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->